### PR TITLE
v0.1.0 → v0.1.1: CC0 bootstrap + LLM-writes-SVG provider strategy / CC0 元件库 + LLM 直出 SVG 策略

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ __pycache__/
 .ruff_cache/
 
 # Local library scratch
-~/sci-illustration-library/
+# (Git does NOT expand ~ in patterns; keep just the repo-relative form so
+# contributors aren't misled by a no-op `~/sci-illustration-library/` rule.)
 sci-illustration-library/
 
 # Editor

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ sci-illustration-library/
 .DS_Store
 .idea/
 .vscode/
+
+# Claude Code session metadata (per-workspace)
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# CC_icons — `scientific-illustration-asset-pipeline`
+
+Local home for the `scientific-illustration-asset-pipeline` skill that turns
+ad-hoc scientific figure work into a reusable, license-clean element library
+plus a half-automated assembly pipeline.
+
+The skill itself ships in [`SKILL.md`](./SKILL.md). This README is the
+operator-facing quickstart for the bootstrap and assembly tooling that lives
+in [`scripts/`](./scripts) and [`templates/`](./templates).
+
+> Skill version: see frontmatter in [`SKILL.md`](./SKILL.md). Open changes
+> are tracked under [`openspec/changes/`](./openspec/changes/).
+
+---
+
+## Bootstrap the CC0 element library / 构建 CC0 元件库
+
+> One-time setup. Plan for **~one overnight run** and **~500 MB on disk**
+> for the full sweep; PhyloPic is the dominant cost.
+>
+> 一次性安装。完整跑完约**通宵一晚**，磁盘**~500 MB**；PhyloPic 是最大头。
+
+### 1. Install dependencies / 安装依赖
+
+```bash
+pip install requests beautifulsoup4 lxml tqdm pyyaml \
+            cairosvg pillow python-pptx
+```
+
+| Package | Used by | Mandatory? |
+|---|---|---|
+| `requests` / `beautifulsoup4` / `lxml` / `tqdm` / `pyyaml` | `download_cc0_seed.py`, `library_tools.py`, `assemble_figure.py` | **Yes** |
+| `cairosvg` + `pillow` | `library_tools.py preview` / `export` | only for thumbnail / PPTX export |
+| `python-pptx` | `library_tools.py export`, `assemble_figure.py --export-pptx` | only when exporting to PPTX |
+| Inkscape ≥ 1.2 (CLI) | `assemble_figure.py --export-pdf*` | only when exporting to PDF |
+
+### 2. Run the full bootstrap / 整库 bootstrap
+
+```bash
+python scripts/download_cc0_seed.py --all --target ~/sci-illustration-library
+```
+
+This walks every source that does **not** require a manual file:
+
+- **BioIcons** — git clone (CC0)
+- **PhyloPic v2** — REST API (CC0/CC-BY per image)
+- **Reactome Icon Library** — git clone (CC BY 4.0)
+- **SciDraw** — light scrape of scidraw.io (CC0)
+
+### 3. Add the manual sources / 加上需要手动下载的两源
+
+Two sources cannot be auto-fetched (the live sites are SPAs or gate downloads
+behind a click-through). Drop the archives anywhere local and point the
+script at them:
+
+```bash
+# Servier Medical Art — get the official PPTX from https://smart.servier.com
+python scripts/download_cc0_seed.py --source servier \
+       --pptx ~/Downloads/servier-anatomy.pptx
+
+# NIH BioArt (NIAID) — pick illustrations from https://bioart.niaid.nih.gov/
+# and zip the resulting downloads
+python scripts/download_cc0_seed.py --source nih_bioart \
+       --zip ~/Downloads/nih_bioart_pack.zip
+```
+
+### 4. Inspect the library / 浏览成果
+
+```bash
+# Stats overview
+python scripts/library_tools.py stats
+
+# Search and filter
+python scripts/library_tools.py search "alpha helix" --license CC0
+python scripts/library_tools.py search --category cells/immune --max 20
+
+# Thumbnail grid PNG
+python scripts/library_tools.py preview --query "neuron" --output preview.png
+
+# Export selected elements to PPTX (one slide per element)
+python scripts/library_tools.py export \
+       --ids "bioicons-tcell-activated,phylopic-fd8d3e5e" \
+       --output ./elements.pptx
+
+# Generate a CC-BY attribution clip ready to paste into a figure caption
+python scripts/library_tools.py attribution --output ./fig1-attribution.md
+```
+
+### 5. Assemble a figure / 组装一张 figure
+
+```bash
+python scripts/assemble_figure.py \
+       --template templates/dark_proteome_4panel_template.svg \
+       --manifest templates/dark_proteome_manifest.yaml \
+       --output ./fig1.svg \
+       --export-pdf --export-pptx
+```
+
+The assembler:
+
+1. resolves each `panels:` value as either a unified-index ID
+   (`bioicons-tcell-activated`) or a relative path (`cells/treg-flat-v1.svg`),
+2. fills `<text id="…">` slots from the manifest's `labels:` map,
+3. injects an automatic `Adapted from: …` caption at the bottom-right when
+   any CC-BY element was used,
+4. normalises fonts and exports SVG / PDF / PPTX as requested.
+
+---
+
+## Out-of-scope (planned for v0.2)
+
+- BioRender connector (waiting on stable MCP exposure).
+- `text_collision_check.py` — auto-detect `<text>` bbox overlaps in
+  LLM-generated SVG.
+- A web UI for library browsing.
+- Per-journal config (Nature / Cell / Lancet color/font specs).
+- **Low-fidelity tracing layer**: re-trace every CC0 / AI element through
+  Inkscape (or Adobe Illustrator) before assembly so visually heterogeneous
+  sources converge to one stylebook, then nest into Inkscape / PPT for
+  PDF / SVG-with-nested-SVG output. Independent step, orthogonal to v0.1.1's
+  ID-resolver and attribution work.
+
+---
+
+## License
+
+Code in this repository is MIT-licensed (see [`LICENSE`](./LICENSE)). Element
+content downloaded by the bootstrap inherits **the original source's** license;
+`library/index.json` records the exact CC URI per element so that
+`library_tools.py attribution` can cite each source correctly. Always re-check
+attribution requirements before publishing — the script is best effort, not
+legal advice.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: scientific-illustration-asset-pipeline
-version: 0.1.0
+version: 0.1.1
 description: |
   Master skill for scientific figure creation via AI-generated element library
-  plus semi-automated assembly. Coordinates multiple AI image providers
-  (Recraft, OpenAI gpt-image, Gemini Imagen, Zhipu GLM CogView, MiniMax) for
-  element generation, manages a versioned local asset library, and automates
-  layout via Inkscape MCP and PowerPoint MCP. Triggers: "做 Fig1", "graphical
+  plus semi-automated assembly. As of v0.1.1, the primary path for *whole-figure*
+  generation is "LLM writes SVG code directly" (Claude / MiniMax / GLM-5.1 /
+  GPT-5), supplemented by a CC0 icon library (~17000 elements from BioIcons,
+  PhyloPic, NIH BioArt, Reactome, SciDraw, Servier Medical Art) for the
+  semi-3D bio-element gap that LLMs cannot draw. Recraft V3 is repositioned
+  as element-level reinforcement only. Triggers: "做 Fig1", "graphical
   abstract", "组装科研图", "用元件库做综述图", "scientific figure assembly",
   "TOC graphic", "review paper schematic".
   This skill orchestrates other skills (recraft-scientific-illustration for
@@ -33,7 +35,146 @@ allowed-tools:
 
 # Scientific Illustration Asset Pipeline v0.1
 
-## 总览：从碎片化到工程化
+## v0.1.1 重大变更摘要（必读）
+
+本版基于一次实战测试做了路径修正。**v0.1.0 把 Recraft 当做整图主力**——这条路在面对"科研图必须文字真节点"时被证伪。修正项：
+
+| 章节 | v0.1.0 | v0.1.1 修订 |
+|---|---|---|
+| 整图主力 provider | Recraft V3 + 矢量化 | **LLM 直出 SVG 代码**（Claude / MiniMax / GLM-5.1 / GPT-5）|
+| Recraft 定位 | 整图 + 元件 | **元件补强**（α-helix / 受体 / 立体器官等半立体元件）|
+| 文字处理 | 提示词避免 | **LLM 路径天然真节点**，仅需 Inkscape 修文字碰撞 |
+| 排版自动化 Level 3 | 标"完全自动化不可能" | **限定为"扩散模型路径不可能"**，LLM 路径 + 元件库可行 |
+| 元件库 bootstrap | 手动一个个生成 | **CC0 公开数据源 6 选一晚跑完，~17000 元件入库** |
+| 投稿 attribution | 未处理 | **assemble_figure.py 自动注入 + library_tools attribution 命令** |
+
+**核心洞察**：LLM 写 SVG 代码（不是图像扩散模型）是科研图的真正赛道。失败模式（文字坐标重叠）比扩散路径的失败模式（文字必糊）易修复 100 倍。详见 `## 一、AI Provider 选择矩阵 § 1.0`。
+
+---
+
+## 零、CC0 元件库 Bootstrap（v0.1.1 新增）
+
+**任何项目第一步**：从 6 个 CC0 / CC-BY / Public Domain 数据源批量下载 ~17000 个矢量科研元件入库，作为后续 figure 组装的"立体元件子弹"。这一步替代 v0.1.0 里"为每个项目单独 Recraft 生成"的低效流程。
+
+### 0.1 数据源清单
+
+| 源 | 授权 | 规模 | 拿法 |
+|---|---|---|---|
+| **BioIcons** | **CC0** | ~1500 SVG | `git clone duerrsimon/bioicons` |
+| **PhyloPic** | CC0 / CC-BY | ~10000 silhouettes | REST API `api.phylopic.org` |
+| **NIH BioArt** (NIAID) | **公有领域** | ~2500 illustrations | manual ZIP drop（站点已是 Next.js SPA，无公开 REST 端点）|
+| **Reactome Icons** | CC BY 4.0 | ~500 SVG | `git clone reactome/icon-lib` |
+| **SciDraw** (Janelia) | **CC0** | ~700 SVG | webscrape `scidraw.io` |
+| **Servier Medical Art** | CC BY 3.0 | ~3000 SVG/EMF | 用户手动下 PPTX 包，脚本拆 |
+
+### 0.2 一晚 bootstrap 命令
+
+```bash
+# 一次性全部下载（一晚跑完，~500MB）
+python scripts/download_cc0_seed.py --all --target ~/sci-illustration-library
+
+# 或限速版（PhyloPic 量大可限）
+python scripts/download_cc0_seed.py --source phylopic --max-per-source 1000
+
+# Servier 需要先手动从 https://smart.servier.com 下 PPTX 包
+python scripts/download_cc0_seed.py --source servier \
+       --pptx ~/Downloads/servier-anatomy.pptx
+
+# NIH BioArt 站点已是 Next.js SPA（无 REST 端点，HTTP 抓取拿不到任何卡片）。
+# 流程：在 https://bioart.niaid.nih.gov/ 浏览并选下载所需 illustration，
+# 打成 ZIP 后投放：
+python scripts/download_cc0_seed.py --source nih_bioart \
+       --zip ~/Downloads/nih_bioart_pack.zip
+```
+
+### 0.3 入库结构
+
+```
+~/sci-illustration-library/
+├── library/
+│   ├── index.json                    ← 元数据 + 授权追溯（统一索引）
+│   ├── cells/
+│   │   ├── immune/                   ← T cell, macrophage, dendritic
+│   │   ├── cancer/
+│   │   ├── neuron/
+│   │   └── general/
+│   ├── molecules/
+│   │   ├── protein/
+│   │   ├── nucleic_acid/
+│   │   └── small/
+│   ├── organelles/
+│   ├── tissues/
+│   ├── organs/
+│   ├── equipment/
+│   │   ├── lab/
+│   │   └── clinical/
+│   └── pathways/
+├── _raw/                             ← 原始下载（git repos, PPTX 解包）
+└── _final/                           ← 项目最终交付目录
+    └── <project-name>/
+```
+
+### 0.4 元数据 schema（`library/index.json`）
+
+每个 icon 一条记录：
+
+```json
+{
+  "id": "bioicons-tcell-activated",
+  "name": "T cell activated",
+  "tags": ["immune", "lymphocyte"],
+  "category": "cells/immune",
+  "source": "bioicons",
+  "source_url": "https://bioicons.com",
+  "license": "CC0",
+  "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "attribution_required": false,
+  "file": "cells/immune/bioicons-tcell-activated.svg",
+  "added_at": "2026-05-02"
+}
+```
+
+CC BY 类型自动 `attribution_required: true` 并填充 `attribution` 字段。投稿前用 `library_tools.py attribution` 一键导出 figure caption 文本。
+
+### 0.5 浏览与搜索
+
+```bash
+# 整库统计
+python scripts/library_tools.py stats
+
+# 搜索元件
+python scripts/library_tools.py search "alpha helix"
+python scripts/library_tools.py search "T cell" --license CC0 --max 20
+python scripts/library_tools.py search --category cells/immune
+
+# 缩略图 grid 浏览
+python scripts/library_tools.py preview --query "neuron" --output preview.png
+
+# 导出选定元件到 PPTX 模板（每元件一 slide，含名称和授权）
+python scripts/library_tools.py export \
+       --ids "bioicons-alpha-helix,phylopic-abc12345" \
+       --output ./elements.pptx
+
+# 投稿前导出 attribution 清单
+python scripts/library_tools.py attribution --output ./fig1-attribution.md
+```
+
+### 0.6 与 Recraft 的关系
+
+CC0 库 ≠ 完全替代 Recraft。两者分工：
+
+| 元件类型 | 优先来源 |
+|---|---|
+| 通用细胞、抗体、酶等扁平 icon | **CC0 库**（BioIcons / Reactome 优先） |
+| 通用 silhouette（动物、人、植物） | **CC0 库**（PhyloPic） |
+| 神经元、电极等 neuro 专用 | **CC0 库**（SciDraw） |
+| 解剖图、医疗设备 | **CC0 库**（Servier / NIH BioArt） |
+| **半立体 cartoon**（α-helix 螺旋柱、HLA-I receptor、立体器官切面） | **Recraft V3** + style reference |
+| 极特殊原创元件 | **手画**（Affinity Designer） |
+
+**新工作流**：先去 `library_tools.py search` 查 CC0 库，**找不到合适的再 Recraft 补**。这样平均每个项目 Recraft 调用次数 ↓ 90%，速度↑、成本↓、license 更干净。
+
+---
 
 这个 skill 解决的核心问题是 **科研图制作的工程化**：
 把每张图从"一次性手工艺品"变成"基于元件库的可组装、可版本化、可复用产物"。
@@ -69,7 +210,69 @@ allowed-tools:
 
 不同模型在不同场景的实测能力差异显著。**选错 provider 是浪费 credit 的最大原因**。
 
-### 1.1 按元件类型选 provider
+### 1.0 整图 vs 元件：两条根本不同的赛道（v0.1.1 重要修订）
+
+科研图生成任务分两层，**用错赛道一定失败**：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  整图 / 4-panel Fig1 / graphical abstract                   │
+│  ────────────────────────────────────                       │
+│  → 走 LLM 写 SVG 代码 (第一档)                                │
+│    Claude / MiniMax M-series / GLM-5.1 / GPT-5              │
+│    优势：文字真节点、节点极少、可编辑、Git diff 友好           │
+│    限制：文字坐标重叠、半立体元件画不精细                       │
+│    修复：Inkscape 5-10 分钟微调 / 元件库补                    │
+│                                                             │
+│  → ❌ 不走 扩散模型 + 矢量化 (Recraft 整图)                    │
+│    会得到：2308 path / 0 text / 文字全糊（实测过）             │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  单个半立体生物元件（α-helix / receptor / cell cartoon）        │
+│  ─────────────────────────────                              │
+│  → 走 元件库优先（CC0 → Recraft V3 → 手画）                    │
+│    扁平 icon → CC0 库已覆盖 80%                                │
+│    半立体 cartoon → Recraft V3（必须 prompt 禁文字）           │
+│    极特殊原创 → Affinity Designer 手画                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**实测数据**（同主题 "dark proteome" 4-panel 对比）：
+
+| Provider | 路径 | `<text>` 节点 | `<path>` | 节点总数 | 文件大小 |
+|---|---|---|---|---|---|
+| Recraft V3 | 扩散 → 矢量化 | **0**（文字必糊） | 2308 | 44661 | 1.8 MB |
+| MiniMax M2.5 | LLM 写代码 | **142** | 31 | 150 | 41 KB |
+| Claude Visualizer | LLM 写代码 | ~80 | ~25 | ~80 | ~36 KB |
+| Claude 独立 SVG | LLM 写代码 | **166** | 24 | 111 | 36.5 KB |
+
+LLM 路径在所有维度都更好（除半立体元件视觉质感的 30%，由元件库补强）。
+
+### 1.0a LLM 直出 SVG（整图主力 prompt 模板）
+
+```
+Generate a complete SVG figure for [TOPIC], Nature Reviews Drug Discovery
+style. 4-panel layout (a/b/c/d), central theme circle, bottom legend strip.
+ViewBox 1600×1000. Constraints:
+- All text as real <text> nodes (must be editable, not paths)
+- Flat colors, no gradients
+- Color-coded panel headers (a=blue, b=green, c=gray, d=purple)
+- Each panel has bold title + subtitle + 4-6 child elements
+- Output ONLY the SVG code, no markdown fence
+```
+
+修复文字碰撞（LLM 路径的固有失败模式）：
+
+```bash
+# Inkscape GUI 微调，5-10 分钟
+inkscape figure.svg
+
+# 或用脚本检测 bbox 冲突（待 v0.2 实现）
+# python scripts/text_collision_check.py figure.svg
+```
+
+### 1.1 单元件 provider（按元件类型）
 
 | 元件类型 | 首选 | 备选 | 避免 |
 |---|---|---|---|
@@ -339,8 +542,14 @@ mcp__inkscape__dom_set(
 ### Level 3: 完全自动化
 基于自然语言描述出最终图。
 
-**适用**：低质量需求场景（讲座 PPT 配图）。
-**严禁用于**：投稿 figure。**架构上不可能产出审稿过线的质量**。
+**v0.1.1 修订**：v0.1.0 标"架构上不可能"，过严。
+
+**实际可行性按路径分**：
+- ❌ **扩散模型路径**（"用 Imagen / Recraft 直接出 Fig1 PNG"）：仍架构不可能。文字必糊。
+- ⚠️ **LLM 写 SVG + 元件库自动填充路径**：**可达 70-80% 投稿质量**。瓶颈在文字坐标重叠 + 半立体元件细节。
+- ✅ **LLM + 元件库 + 5 分钟人工微调**：可达 95% 投稿质量，等价于 BioRender + Affinity 手做的 90% 时间。
+
+**新结论**：投稿 figure 推荐 Level 1+2 混合（LLM 写骨架 + 元件库填充 + 人工 polish），不再禁止 Level 3 探索。
 
 ---
 
@@ -565,7 +774,18 @@ PPT 里嵌入 SVG，导出后 SVG 仍可在 Inkscape/Affinity 编辑——
 
 ## 九、版本历史与限制
 
-### 当前版本（v0.1.0）已支持
+### v0.1.1（current）新增
+- **零章 CC0 元件库 bootstrap**：6 数据源 ~17000 元件一键下载
+- **download_cc0_seed.py**：BioIcons / PhyloPic / NIH BioArt / Reactome / SciDraw / Servier
+- **library_tools.py 升级**：`stats` / `preview` (缩略图 grid) / `export` (PPTX) / `attribution` 4 个新命令
+- **统一索引**：`library/index.json` 合并 CC0 bulk + legacy YAML
+- **assemble_figure.py 升级**：支持按 unified ID 引用元件、自动注入 CC BY attribution、PNG/EMF 元件回退到 `<image>` 引用
+- **示例模板与 manifest**：`templates/dark_proteome_4panel_template.svg` + 配套 manifest YAML
+- **整图主力 provider 修订**：从 Recraft 改为 LLM 直出 SVG（Claude / MiniMax / GLM-5.1 / GPT-5）
+- **Recraft 重新定位**：仅做半立体元件补强，不再担任整图主力
+- **Level 3 评估更新**：撤回"完全自动化不可能"，限定为"扩散模型路径不可能"
+
+### v0.1.0 已支持（保留）
 - Recraft / Gemini / Zhipu GLM / MiniMax 元件生成
 - vectorizer.ai 矢量化
 - Inkscape MCP 自动化排版
@@ -574,17 +794,24 @@ PPT 里嵌入 SVG，导出后 SVG 仍可在 Inkscape/Affinity 编辑——
 
 ### 已知限制
 - WPS Office 无 MCP，只能通过兼容打开 PPTX
-- Claude 无图像生成 API，无法作为元件 provider
-- 完全自动化排版仍是开放问题（设计本质决定）
+- ~~Claude 无图像生成 API，无法作为元件 provider~~ → **v0.1.1 修订**：Claude 通过 Visualizer / 直接写 SVG 代码可以作为整图 provider
+- ~~完全自动化排版仍是开放问题~~ → **v0.1.1 修订**：限定为扩散路径，LLM + 元件库路径已可达 70-80%
 - 中文字体处理在 Inkscape 上仍需手动指定（思源黑体等）
+- LLM 写 SVG 的固有失败模式：文字坐标重叠（需 5-10 分钟 Inkscape 微调）
+- BioRender 集成（订阅用户合规路径）：v0.1.1 暂不实现，等 BioRender MCP 工具暴露后另行评估
 
 ### 计划 v0.2
 - 增加元件库 Web UI 检索（取代 grep _index.yaml）
 - 增加 Style Reference 自动校验（每周扫描漂移）
 - 增加投稿期刊配置文件（Nature/Cell/Lancet 各家的色板/字号/尺寸规范）
+- **`text_collision_check.py`**：自动检测 LLM 输出 SVG 中 `<text>` bbox 重叠并提示修复
+- **BioRender connector 集成**（个人订阅合规路径）
+- **元件库 web preview**：基于 cmd_preview，前端浏览器可点击下载
+- **低保真描摹层**（low-fidelity tracing layer）：对每一个 CC0 / AI 生成的 SVG 元件先经过 Inkscape / Adobe Illustrator 的低保真 trace 步骤，让风格异质的多源元件在嵌入模板前**先收敛到同一笔触/色板/抽象层级**，再用 Inkscape / PPT 排版输出 PDF / SVG-内嵌-SVG。这是和本版 ID 解析与 attribution 注入正交的独立步骤，单独排期，不进 v0.1.1。
 
 ### 设计原则（不会改变）
 1. **80% 自动 + 20% 人决策** —— 视觉层级永远人定
 2. **元件库优先** —— 重复使用 > 重新生成
-3. **可追溯性强制** —— 每张图必须有 elements-used.yaml
-4. **Git 版本化** —— 元件库本身是可分享的资产
+3. **CC0 优先** —— 不分发受版权保护的素材
+4. **可追溯性强制** —— 每张图必须有 elements-used.yaml + attribution 清单
+5. **Git 版本化** —— 元件库本身是可分享的资产

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ allowed-tools:
 flowchart LR
     A[科研 figure 需求<br/>Fig1 / TOC /<br/>graphical abstract<br/>可选 PNG 底图输入] --> B[0. Bootstrap<br/>CC0 元件库 ~17000<br/>download_cc0_seed.py --all]
     B --> C[1. LLM 写 SVG 骨架<br/>MiniMax 首选<br/>量大 / 便宜 / 清晰<br/>备选 Claude / GLM-5.1 / GPT-5]
-    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 4 Vector Pro<br/>补半立体或缺失元件]
+    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 4 Vector / 4 Vector Pro<br/>前者便宜<br/>元件丑陋则用后者<br/>补半立体或缺失元件]
     D --> E[3. 模板装配<br/>assemble_figure.py<br/>+ 自动 CC-BY 归属注入<br/>+ 字体规范化]
     E --> F[4. Inkscape / PowerPoint 微调<br/>修文字碰撞<br/>5-10 分钟<br/>只配一个 MCP 就用所配那个]
     F --> G[5. 导出<br/>SVG 编辑<br/>PDF 投稿<br/>PPTX 汇报]

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,35 @@ allowed-tools:
 
 # Scientific Illustration Asset Pipeline v0.1
 
+## 一图看懂流水线 / Pipeline at a Glance
+
+```mermaid
+flowchart LR
+    A[科研 figure 需求<br/>Fig1 / TOC /<br/>graphical abstract] --> B[0. Bootstrap<br/>CC0 元件库 ~17000<br/>download_cc0_seed.py --all]
+    B --> C[1. LLM 写 SVG 骨架<br/>MiniMax 首选<br/>量大 / 便宜 / 清晰<br/>备选 Claude / GLM-5.1 / GPT-5]
+    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 补半立体]
+    D --> E[3. 模板装配<br/>assemble_figure.py<br/>+ 自动 CC-BY 归属注入<br/>+ 字体规范化]
+    E --> F[4. Inkscape 微调<br/>修文字碰撞<br/>5-10 分钟]
+    F --> G[5. 导出<br/>SVG 编辑<br/>PDF 投稿<br/>PPTX 汇报]
+
+    style A fill:#FFFFFF,stroke:#1B3A6E,stroke-width:2px,color:#1B3A6E
+    style B fill:#F2F8FD,stroke:#2E7CD6,color:#1B5BA0
+    style C fill:#F2FAF4,stroke:#4FA85F,stroke-width:3px,color:#2E7B3D
+    style D fill:#F8F8F4,stroke:#888,color:#333
+    style E fill:#F7F4FA,stroke:#8B5CB7,color:#6B3F9A
+    style F fill:#FDF6F4,stroke:#A32D2D,color:#A32D2D
+    style G fill:#FAFAF7,stroke:#666,stroke-width:2px,color:#333
+```
+
+读图速记：
+
+- **Bootstrap 一次到位**（步骤 0，约一晚）→ 后续每个项目从步骤 1 开始
+- **整图骨架 ≠ 元件**：骨架用 LLM 写代码（步骤 1，**MiniMax 首选**），元件来自 CC0 库（步骤 2）
+- **机器主导步骤 0–3、5；人主导步骤 4**（视觉层级和文字内容由人决定）
+- **每张投稿图都带可追溯的 attribution 清单**（步骤 3 自动注入，步骤 5 同步导出）
+
+---
+
 ## v0.1.1 重大变更摘要（必读）
 
 本版基于一次实战测试做了路径修正。**v0.1.0 把 Recraft 当做整图主力**——这条路在面对"科研图必须文字真节点"时被证伪。修正项：

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,11 +39,11 @@ allowed-tools:
 
 ```mermaid
 flowchart LR
-    A[科研 figure 需求<br/>Fig1 / TOC /<br/>graphical abstract] --> B[0. Bootstrap<br/>CC0 元件库 ~17000<br/>download_cc0_seed.py --all]
+    A[科研 figure 需求<br/>Fig1 / TOC /<br/>graphical abstract<br/>可选 PNG 底图输入] --> B[0. Bootstrap<br/>CC0 元件库 ~17000<br/>download_cc0_seed.py --all]
     B --> C[1. LLM 写 SVG 骨架<br/>MiniMax 首选<br/>量大 / 便宜 / 清晰<br/>备选 Claude / GLM-5.1 / GPT-5]
-    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 补半立体]
+    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 4 Vector Pro<br/>补半立体或缺失元件]
     D --> E[3. 模板装配<br/>assemble_figure.py<br/>+ 自动 CC-BY 归属注入<br/>+ 字体规范化]
-    E --> F[4. Inkscape 微调<br/>修文字碰撞<br/>5-10 分钟]
+    E --> F[4. Inkscape / PowerPoint 微调<br/>修文字碰撞<br/>5-10 分钟<br/>只配一个 MCP 就用所配那个]
     F --> G[5. 导出<br/>SVG 编辑<br/>PDF 投稿<br/>PPTX 汇报]
 
     style A fill:#FFFFFF,stroke:#1B3A6E,stroke-width:2px,color:#1B3A6E

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ allowed-tools:
 
 | 章节 | v0.1.0 | v0.1.1 修订 |
 |---|---|---|
-| 整图主力 provider | Recraft V3 + 矢量化 | **LLM 直出 SVG 代码**（Claude / MiniMax / GLM-5.1 / GPT-5）|
+| 整图主力 provider | Recraft V3 + 矢量化 | **LLM 直出 SVG 代码**（**MiniMax M-series 首选**：量大管饱 / 清晰 / 色块少 / 比 Recraft 便宜 / 适合带文字 + placeholder；备选 Claude / GLM-5.1 / GPT-5）|
 | Recraft 定位 | 整图 + 元件 | **元件补强**（α-helix / 受体 / 立体器官等半立体元件）|
 | 文字处理 | 提示词避免 | **LLM 路径天然真节点**，仅需 Inkscape 修文字碰撞 |
 | 排版自动化 Level 3 | 标"完全自动化不可能" | **限定为"扩散模型路径不可能"**，LLM 路径 + 元件库可行 |
@@ -262,6 +262,19 @@ ViewBox 1600×1000. Constraints:
 - Output ONLY the SVG code, no markdown fence
 ```
 
+#### 写 SVG 代码的 LLM provider 选型
+
+| Provider | 文字 | 节点密度 | 量大管饱? | 单价倾向 | 推荐场景 |
+|---|---|---|---|---|---|
+| **MiniMax M-series** | 真节点（中英都强） | 低（色块少、清晰） | ✅ 量大管饱 | **比 Recraft 便宜** | **首选**：含**文字 + placeholder** 的 SVG / PDF（投稿 figure / TOC / graphical abstract）|
+| Claude (Visualizer / 直接对话) | 真节点 | 低 | ⚠️ 视套餐 | 中 | 复杂语义（如 "把这条 pathway 重新组织"），需要推理时 |
+| GLM-5.1 | 真节点（中文极强） | 中 | ✅ | 低 | 中文标题/标注密集场景 |
+| GPT-5 | 真节点 | 中 | ⚠️ 视套餐 | 中-高 | 需精细 prompt 控制 / 严格遵照规格时 |
+
+**MiniMax 主战场**：当一张图里包含**多个文字标签 + 待填 placeholder + 图形元件**时（即典型 4-panel figure），MiniMax 既能保证文字真节点，又能把色块画得简洁规范，且**单价低，可批量重试**——比 Recraft 整图链便宜多倍，是 v0.1.1 默认推荐路径。
+
+⚠️ **MiniMax 不做 PNG → SVG 矢量化**。如需把扩散模型出来的 PNG 转 SVG，走 §二（vectorizer.ai / Inkscape Trace），不要让 MiniMax 接 PNG 输入。
+
 修复文字碰撞（LLM 路径的固有失败模式）：
 
 ```bash
@@ -274,28 +287,38 @@ inkscape figure.svg
 
 ### 1.1 单元件 provider（按元件类型）
 
+> 这一节只覆盖**单元件**（cell / receptor / enzyme 之类的图标素材）。整图（Fig1 / TOC / graphical abstract）走 §1.0a 的 LLM 写 SVG 路径，**MiniMax / Claude / GLM-5.1 / GPT-5 是整图主力，不在本表中重复**。
+
 | 元件类型 | 首选 | 备选 | 避免 |
 |---|---|---|---|
 | 抽象生物元件（细胞、蛋白）| **Recraft V3** (vector) | Gemini Imagen 4 | OpenAI DALL-E |
 | 写实解剖结构（器官、组织）| **Gemini Imagen 4** | OpenAI gpt-image | Recraft (太抽象) |
-| 中文标签 / 中文场景 | **智谱 CogView-4** | MiniMax | Recraft (中文糊) |
+| 中文标签 / 中文场景（PNG 路径）| **智谱 CogView-4** | OpenAI gpt-image | Recraft (中文糊) |
 | 实验装置（仪器、培养皿）| **Recraft V3** | Gemini Imagen 4 | - |
 | 信号通路单点（受体激活等）| **Recraft V3** | - | - |
 | 流程图节点（圆角矩形等）| **不要用 AI** | 直接用 Inkscape/PPT 画 | 任何 AI |
 | 手绘风/插画风 | OpenAI gpt-image | Gemini | Recraft (太程式化) |
 
+> **MiniMax 不在本表里**：MiniMax 没有 PNG → SVG 矢量化能力，强项是直接写 SVG 代码（见 §1.0a）。把它当 PNG 元件 provider 用是错配；中文 PNG 元件场景由 CogView-4 覆盖即可。
+
 ### 1.2 按输出格式区分
 
-| Provider | 直出 SVG | 直出 PNG | 中文 | 一致性 (style ref) |
-|---|---|---|---|---|
-| Recraft V3 | ✅ | ✅ | 弱 | ✅ 强 |
-| OpenAI gpt-image | ❌ | ✅ | 中 | ❌ 无 style API |
-| Gemini Imagen 4 | ❌ | ✅ | 中 | ⚠️ 通过 reference image |
-| 智谱 GLM CogView-4 | ❌ | ✅ | **强** | ❌ |
-| MiniMax | ❌ | ✅ | **强** | ❌ |
+把"出 SVG"拆成两条**根本不同**的产能：扩散模型直出 vs LLM 写代码。前者文字必糊（v0.1.1 已实证），后者文字真节点。两个不能合并成一列。
 
-**关键推论**：除了 Recraft 直出 SVG，其他全部需要 PNG → SVG 矢量化步骤。
-矢量化质量取决于元件复杂度——单元件简单背景，矢量化效果可接受。
+| Provider | LLM 写 SVG 代码 | 扩散直出 SVG | 直出 PNG | 中文 | style ref |
+|---|---|---|---|---|---|
+| **MiniMax M-series** | ✅ **强**（量大管饱、清晰、色块少、便宜） | ❌ | ✅ | **强** | ❌ |
+| Claude (Visualizer / 对话) | ✅ 强（推理强） | ❌ | ❌ | 强 | ❌ |
+| GLM-5.1 | ✅ 中 | — | ✅（CogView-4）| **强** | ❌ |
+| GPT-5 | ✅ 中（按规格严谨） | ❌ | ✅（gpt-image）| 中 | ❌ |
+| Recraft V3 | ❌ | ✅（**文字必糊**，仅适合无字元件）| ✅ | 弱 | ✅ 强 |
+| Gemini Imagen 4 | ❌ | ❌ | ✅ | 中 | ⚠️ via reference image |
+| OpenAI gpt-image | ❌ | ❌ | ✅ | 中 | ❌ |
+
+**关键推论（v0.1.1 修订）**：
+- 整图走「LLM 写 SVG 代码」第一档（MiniMax 首选，便宜+量大），文字真节点 → 直接可投稿；
+- 单元件走「扩散直出 SVG / PNG → 矢量化」（Recraft V3 / Gemini / CogView-4），但**禁文字**；
+- 同一 provider 两种产能不要混用（不要让 Recraft 出整图，不要让 MiniMax 接 PNG 矢量化）。
 
 ### 1.3 MCP 端点配置参考
 
@@ -349,7 +372,13 @@ inkscape figure.svg
 
 ## 二、PNG → SVG 矢量化层
 
-非 Recraft 来源的元件必须经此步骤。
+> **本节只针对**走"扩散模型 / 栅格 provider 出 PNG → 转 SVG"路径的**单元件**生成。
+>
+> **MiniMax / Claude / GLM-5.1 / GPT-5 不走这一节** —— 它们直接撰写 SVG 代码（§1.0a），既没有 PNG → SVG 矢量化能力，也不需要这条链。把 MiniMax 的 PNG 输出再去走 vectorizer.ai 是错配。
+>
+> 本节适用：Recraft V3 (vector 端点之外的) / Gemini Imagen 4 / OpenAI gpt-image / 智谱 CogView-4 出的 PNG。
+
+非 LLM-写-SVG 来源的元件必须经此步骤。
 
 ### 矢量化方案对比
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -337,6 +337,7 @@ inkscape figure.svg
 | 中文标签 / 中文场景（PNG 路径）| **智谱 CogView-4** | OpenAI gpt-image | Recraft (中文糊) |
 | 实验装置（仪器、培养皿）| **Recraft V3** | Gemini Imagen 4 | - |
 | 信号通路单点（受体激活等）| **Recraft V3** | - | - |
+| **轮廓 / 结构化元件**（昆虫触角、神经元突起、解剖切面线条、骨架图等） | **GPT Image 2 outline → vectorize → Inkscape 着色** | OpenAI gpt-image (sketch prompt) | Recraft (色块过密、轮廓被切碎) |
 | 流程图节点（圆角矩形等）| **不要用 AI** | 直接用 Inkscape/PPT 画 | 任何 AI |
 | 手绘风/插画风 | OpenAI gpt-image | Gemini | Recraft (太程式化) |
 
@@ -462,6 +463,64 @@ def preprocess_for_vectorization(png_path: Path, output_path: Path) -> None:
 ```
 
 预处理后再送 vectorizer.ai：节点数能减少 60–80%，颜色规范回到可控范围。
+
+### 2.x 轮廓素材的双段处理（结构化元件最划算）
+
+**适用场景**：CC0 库未覆盖、Recraft 又把元件画得"色块太碎太丑"的结构化元件——昆虫触角、神经元突起、解剖切面线条、骨架图、机械装置示意。
+
+**核心原则**：让 AI 只负责**轮廓**，色块由人在 Inkscape 里套项目色板手动填——这两件事各自最快。
+
+**第 1 段：高级 PNG 模型出素描风轮廓**
+
+```text
+prompt 模板：
+Generate a [SUBJECT] in pure outline / line-art style.
+Strict constraints:
+- Only black contour lines on transparent or pure-white background
+- NO interior fill, NO shading, NO color blocks, NO gradients
+- Continuous strokes for body / wings / antennae / segments
+- Anatomically accurate proportions
+- 1024×1024, square crop, subject centered
+```
+
+实测 prompt 收敛要点：
+- "pure outline" "line-art" "no fill" 三个词必须同时给，单给"sketch"会带阴影；
+- 给一两个对照样图作 reference image（Gemini / GPT Image 2 都支持）效果最稳；
+- 明确禁止"color"、"shading"、"watercolor" 关键词，避免半透明渗色。
+
+provider 选型（**仅讨论"出无填色轮廓"这条路径**）：
+
+| Provider | 轮廓服从度 | 解剖准确度 | 成本 | 备注 |
+|---|---|---|---|---|
+| **GPT Image 2** | 强 | 高 | 中 | 首选，prompt 服从最稳 |
+| Gemini Imagen 4 | 中 | 中 | 中 | 提供参考图时更稳 |
+| OpenAI gpt-image | 中 | 中 | 中 | 偶尔渗 watercolor，需明确禁止 |
+| Recraft | ⚠️ | - | 低 | **不要走这条路径**：色块产出器，禁色块时反而画不出形 |
+
+**第 2 段：矢量化 + 着色**
+
+线稿矢量化的天然优势：
+
+| 指标 | 全色块 PNG（直接出色块的图） | 纯轮廓 PNG（本路径） |
+|---|---|---|
+| 矢量化后路径节点数 | 数千（每色块一组） | 数十～数百（描边一组） |
+| 半透明伪色层（沾水） | 严重，需 quantize 预处理 | 几乎没有，直接 trace 即可 |
+| Inkscape 编辑友好度 | 节点过多，难二次加工 | 节点干净，套色板秒填 |
+| 修改单一颜色 | 多组路径联动，容易漏 | 一组 fill，秒切 |
+
+```bash
+# Step 2a: 矢量化（轮廓图直接走 Inkscape Trace 即够，省 vectorizer.ai 钱）
+inkscape input-outline.png \
+  --actions="select-all;trace-bitmap-brightness;export-filename:traced.svg;export-do" \
+  --batch-process
+
+# Step 2b: 在 Inkscape GUI 里着色
+# 1) Edit → Find/Replace → 选所有 path → 设 stroke / fill 用项目色板
+# 2) 或用 swatches 面板一键应用 nature-flat-blue 色板
+# 3) 导出最终 svg；走 library_tools.py register --provider gpt-image2-outline 入库
+```
+
+**入库元数据约定**：register 时 `--provider gpt-image2-outline`（或 `gemini-outline` 等），让 audit / search 能区分这一档元件的来源——它和扩散+矢量化的色块 SVG 在节点密度、可编辑性上有显著差异，下游报告要分开统计。
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,15 +41,26 @@ allowed-tools:
 flowchart LR
     A[科研 figure 需求<br/>Fig1 / TOC /<br/>graphical abstract<br/>可选 PNG 底图输入] --> B[0. Bootstrap<br/>CC0 元件库 ~17000<br/>download_cc0_seed.py --all]
     B --> C[1. LLM 写 SVG 骨架<br/>MiniMax 首选<br/>量大 / 便宜 / 清晰<br/>备选 Claude / GLM-5.1 / GPT-5]
-    C --> D[2. 搜库填元件<br/>library_tools.py search<br/>CC0 优先<br/>Recraft 4 Vector / 4 Vector Pro<br/>前者便宜<br/>元件丑陋则用后者<br/>补半立体或缺失元件]
-    D --> E[3. 模板装配<br/>assemble_figure.py<br/>+ 自动 CC-BY 归属注入<br/>+ 字体规范化]
+    C --> D1[2a. 搜 CC0 库<br/>library_tools.py search]
+    D1 -->|命中| E
+    D1 -->|缺色块/半立体元件| D2[2b. Recraft 4 Vector / 4 Vector Pro<br/>前者便宜<br/>元件丑陋则用后者<br/>直出色块 SVG]
+    D1 -->|缺轮廓/结构化元件| D3[2c. 高级 PNG 模型<br/>GPT Image 2 等<br/>只画身体/翅膀/触手轮廓<br/>不画内部色块, 类素描风]
+    D3 --> D4[2c'. PNG → SVG 矢量化<br/>vectorizer.ai / Inkscape Trace<br/>线稿矢量化质量高]
+    D4 --> D5[2c''. Inkscape 着色<br/>套项目色板]
+    D2 --> E
+    D5 --> E
+    E[3. 模板装配<br/>assemble_figure.py<br/>+ 自动 CC-BY 归属注入<br/>+ 字体规范化]
     E --> F[4. Inkscape / PowerPoint 微调<br/>修文字碰撞<br/>5-10 分钟<br/>只配一个 MCP 就用所配那个]
     F --> G[5. 导出<br/>SVG 编辑<br/>PDF 投稿<br/>PPTX 汇报]
 
     style A fill:#FFFFFF,stroke:#1B3A6E,stroke-width:2px,color:#1B3A6E
     style B fill:#F2F8FD,stroke:#2E7CD6,color:#1B5BA0
     style C fill:#F2FAF4,stroke:#4FA85F,stroke-width:3px,color:#2E7B3D
-    style D fill:#F8F8F4,stroke:#888,color:#333
+    style D1 fill:#F8F8F4,stroke:#888,color:#333
+    style D2 fill:#F8F8F4,stroke:#888,color:#333
+    style D3 fill:#FFF6E5,stroke:#C8A431,color:#7A5D14
+    style D4 fill:#FFF6E5,stroke:#C8A431,color:#7A5D14
+    style D5 fill:#FFF6E5,stroke:#C8A431,color:#7A5D14
     style E fill:#F7F4FA,stroke:#8B5CB7,color:#6B3F9A
     style F fill:#FDF6F4,stroke:#A32D2D,color:#A32D2D
     style G fill:#FAFAF7,stroke:#666,stroke-width:2px,color:#333
@@ -58,7 +69,8 @@ flowchart LR
 读图速记：
 
 - **Bootstrap 一次到位**（步骤 0，约一晚）→ 后续每个项目从步骤 1 开始
-- **整图骨架 ≠ 元件**：骨架用 LLM 写代码（步骤 1，**MiniMax 首选**），元件来自 CC0 库（步骤 2）
+- **整图骨架 ≠ 元件**：骨架用 LLM 写代码（步骤 1，**MiniMax 首选**），元件走步骤 2 的 DAG
+- **步骤 2 是 DAG 不是单点**：CC0 命中直进装配；缺色块/半立体元件走 **Recraft 色块 SVG**；缺轮廓/结构化元件（如蟑螂的身体+翅膀+触手）走 **GPT Image 2 等高级 PNG → 素描风轮廓 → 矢量化 → Inkscape 着色** 三段链，最后这条对昆虫触角、神经元突起、解剖切面线条等"结构化但 CC0 库未必覆盖"的元件最划算
 - **机器主导步骤 0–3、5；人主导步骤 4**（视觉层级和文字内容由人决定）
 - **每张投稿图都带可追溯的 attribution 清单**（步骤 3 自动注入，步骤 5 同步导出）
 

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+assemble_figure.py — fill an SVG template from a manifest, normalize fonts,
+inject CC-BY attribution, and export SVG / PDF / PPTX.
+
+Workflow:
+  template SVG  +  manifest.yaml  ->  filled SVG  ->  PDF / PPTX
+
+  manifest.panels: { placeholder-id : element-id-or-relative-path }
+  manifest.labels: { text-element-id : "string content" }
+
+Dependencies:
+  - lxml, pyyaml         (always)
+  - Inkscape >= 1.2 CLI  (PDF / PNG export)
+  - python-pptx          (PPTX export, optional)
+
+Usage:
+  python assemble_figure.py \
+      --template templates/dark_proteome_4panel_template.svg \
+      --manifest templates/dark_proteome_manifest.yaml \
+      --output ./fig1.svg \
+      --export-pdf --export-pptx
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from lxml import etree
+
+
+SVG_NS = {
+    "svg": "http://www.w3.org/2000/svg",
+    "xlink": "http://www.w3.org/1999/xlink",
+}
+SVG_TAG = "{http://www.w3.org/2000/svg}"
+XLINK_HREF = "{http://www.w3.org/1999/xlink}href"
+
+
+# ---------------------------------------------------------------------------
+# Manifest + element resolution
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(manifest_path: Path) -> dict:
+    """Load the YAML manifest as a plain dict."""
+    return yaml.safe_load(manifest_path.read_text())
+
+
+def resolve_element_path(value: str, library_root: Path) -> Path:
+    """Map a manifest value to an actual on-disk file.
+
+    Disambiguation:
+      * "/" in value or extension in {.svg, .png, .emf}  ->  treated as a
+        path relative to `library_root`.
+      * else  ->  treated as a unified-index ID, looked up in
+        library_root/library/index.json.
+    """
+    if "/" in value or value.lower().endswith((".svg", ".png", ".emf")):
+        return library_root / value
+
+    json_index = library_root / "library" / "index.json"
+    if not json_index.exists():
+        return library_root / value
+    try:
+        records: list[dict] = json.loads(json_index.read_text())
+        for r in records:
+            if r.get("id") == value:
+                return library_root / "library" / r["file"]
+    except Exception:
+        pass
+    return library_root / value
+
+
+def lookup_attribution(value: str, library_root: Path) -> dict | None:
+    """If `value` is a unified-index ID for a CC-BY element, return its record."""
+    if "/" in value or value.lower().endswith((".svg", ".png", ".emf")):
+        return None
+    json_index = library_root / "library" / "index.json"
+    if not json_index.exists():
+        return None
+    try:
+        for r in json.loads(json_index.read_text()):
+            if r.get("id") == value and r.get("attribution_required"):
+                return r
+    except Exception:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Template filling
+# ---------------------------------------------------------------------------
+
+
+def _find_placeholders(root: etree._Element, panel_id: str) -> list[etree._Element]:
+    """Return SVG nodes whose `data-placeholder` attr equals `panel_id`.
+
+    Uses lxml's `findall` with attribute predicate to avoid dynamic xpath
+    string injection from manifest keys.
+    """
+    return root.findall(
+        f'.//svg:*[@data-placeholder="{panel_id}"]',
+        namespaces=SVG_NS,
+    ) if not _suspicious_id(panel_id) else []
+
+
+def _suspicious_id(panel_id: str) -> bool:
+    """Reject IDs containing chars that could break the xpath literal."""
+    return any(c in panel_id for c in ('"', "\n", "\r"))
+
+
+def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) -> None:
+    """Write a filled SVG with element bodies + label text + attribution caption."""
+    parser = etree.XMLParser(remove_blank_text=False)
+    tree = etree.parse(str(template_path), parser)
+    root = tree.getroot()
+
+    library_root = Path(
+        manifest.get("library_root", "~/sci-illustration-library")
+    ).expanduser()
+
+    used_attribution: list[dict] = []
+
+    # 1. Element placeholders.
+    for panel_id, element_value in (manifest.get("panels") or {}).items():
+        if _suspicious_id(panel_id):
+            print(f"Warning: rejecting suspicious placeholder id: {panel_id!r}",
+                  file=sys.stderr)
+            continue
+
+        element_full_path = resolve_element_path(element_value, library_root)
+        if not element_full_path.exists():
+            print(f"Warning: element not found: {element_full_path} "
+                  f"(value='{element_value}')", file=sys.stderr)
+            continue
+
+        attr_record = lookup_attribution(element_value, library_root)
+        if attr_record is not None:
+            used_attribution.append(attr_record)
+
+        placeholders = _find_placeholders(root, panel_id)
+        if not placeholders:
+            print(f"Warning: placeholder '{panel_id}' not in template", file=sys.stderr)
+            continue
+
+        if element_full_path.suffix.lower() == ".svg":
+            try:
+                elem_tree = etree.parse(str(element_full_path))
+                elem_root = elem_tree.getroot()
+            except Exception as exc:
+                print(f"Warning: failed to parse {element_full_path}: {exc}",
+                      file=sys.stderr)
+                continue
+
+            for placeholder in placeholders:
+                parent = placeholder.getparent()
+                if parent is None:
+                    continue
+                wrapper = etree.SubElement(
+                    parent, f"{SVG_TAG}g",
+                    attrib={
+                        "id": f"panel-{panel_id}",
+                        "transform": placeholder.get("transform", ""),
+                    },
+                )
+                # Deep-copy each child so two placeholders sharing one source
+                # SVG don't share node identity.
+                for child in elem_root:
+                    wrapper.append(copy.deepcopy(child))
+                parent.remove(placeholder)
+        else:
+            for placeholder in placeholders:
+                parent = placeholder.getparent()
+                if parent is None:
+                    continue
+                etree.SubElement(
+                    parent, f"{SVG_TAG}image",
+                    attrib={
+                        "id": f"panel-{panel_id}",
+                        "x": placeholder.get("x", "0"),
+                        "y": placeholder.get("y", "0"),
+                        "width": placeholder.get("width", "100"),
+                        "height": placeholder.get("height", "100"),
+                        XLINK_HREF: str(element_full_path),
+                    },
+                )
+                parent.remove(placeholder)
+
+        print(f"[fill] panel {panel_id} <- {element_value}")
+
+    # 2. Text labels.
+    for label_id, text_content in (manifest.get("labels") or {}).items():
+        if _suspicious_id(label_id):
+            print(f"Warning: rejecting suspicious label id: {label_id!r}", file=sys.stderr)
+            continue
+        text_elems = root.findall(
+            f'.//svg:text[@id="{label_id}"]',
+            namespaces=SVG_NS,
+        )
+        if not text_elems:
+            print(f"Warning: label '{label_id}' not in template", file=sys.stderr)
+            continue
+        for t in text_elems:
+            for child in list(t):
+                t.remove(child)
+            t.text = str(text_content)
+            print(f"[fill] label {label_id} <- '{text_content}'")
+
+    # 3. Attribution caption.
+    if used_attribution:
+        attr_lines = sorted({
+            r.get("attribution") or f"{r.get('source_name', '')} ({r.get('license', '')})"
+            for r in used_attribution
+        })
+        attr_text = "Adapted from: " + "; ".join(attr_lines)
+        viewbox = (root.get("viewBox") or "0 0 1600 1000").split()
+        canvas_w = float(viewbox[2]) if len(viewbox) >= 4 else 1600.0
+        canvas_h = float(viewbox[3]) if len(viewbox) >= 4 else 1000.0
+        attr_node = etree.SubElement(
+            root, f"{SVG_TAG}text",
+            attrib={
+                "x": str(canvas_w - 10),
+                "y": str(canvas_h - 5),
+                "text-anchor": "end",
+                "font-size": "8",
+                "fill": "#888",
+                "font-family": "Arial",
+                "class": "attribution",
+            },
+        )
+        attr_node.text = attr_text
+        print(f"[attribution] injected: {attr_text[:80]}...")
+
+    tree.write(str(output_path), xml_declaration=True,
+               encoding="utf-8", pretty_print=True)
+    print(f"[fill] saved: {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Font normalization & exports
+# ---------------------------------------------------------------------------
+
+
+def normalize_fonts(svg_path: Path, font_family: str) -> None:
+    """Force every text-bearing element to use one font-family."""
+    tree = etree.parse(str(svg_path))
+    root = tree.getroot()
+
+    count = 0
+    for elem in root.iter():
+        if elem.get("font-family"):
+            elem.set("font-family", font_family)
+            count += 1
+        style = elem.get("style", "")
+        if "font-family" in style:
+            parts: list[str] = []
+            for chunk in style.split(";"):
+                if chunk.strip().startswith("font-family"):
+                    parts.append(f"font-family:{font_family}")
+                else:
+                    parts.append(chunk)
+            elem.set("style", ";".join(parts))
+            count += 1
+
+    tree.write(str(svg_path), xml_declaration=True, encoding="utf-8")
+    print(f"[font] normalized {count} elements -> {font_family}")
+
+
+def export_pdf(svg_path: Path, pdf_path: Path, outline_text: bool = False) -> None:
+    """Export PDF via Inkscape; for submission, set outline_text=True."""
+    cmd = [
+        "inkscape", str(svg_path),
+        "--export-type=pdf",
+        "--export-pdf-version=1.5",
+        f"--export-text-to-path={'true' if outline_text else 'false'}",
+        f"--export-filename={pdf_path}",
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)
+    print(f"[export] PDF: {pdf_path}")
+
+
+def export_pptx(svg_path: Path, pptx_path: Path) -> None:
+    """Render the SVG to a high-DPI PNG and embed into a 16:9 PPTX slide."""
+    try:
+        from pptx import Presentation
+        from pptx.util import Inches
+    except ImportError:
+        print("Warning: python-pptx not installed; skipping PPTX export.",
+              file=sys.stderr)
+        print("  pip install python-pptx", file=sys.stderr)
+        return
+
+    png_temp = svg_path.with_suffix(".tmp.png")
+    subprocess.run([
+        "inkscape", str(svg_path),
+        "--export-type=png",
+        "--export-dpi=300",
+        f"--export-filename={png_temp}",
+    ], check=True, capture_output=True)
+
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)  # 16:9
+    prs.slide_height = Inches(7.5)
+    blank_layout = prs.slide_layouts[6]
+    slide = prs.slides.add_slide(blank_layout)
+    slide.shapes.add_picture(
+        str(png_temp),
+        left=Inches(0.5), top=Inches(0.5),
+        width=Inches(12.333), height=Inches(6.5),
+    )
+
+    prs.save(str(pptx_path))
+    png_temp.unlink(missing_ok=True)
+    print(f"[export] PPTX: {pptx_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Template-driven scientific figure assembler")
+    parser.add_argument("--template", type=Path, required=True, help="SVG template")
+    parser.add_argument("--manifest", type=Path, required=True, help="manifest YAML")
+    parser.add_argument("--output", type=Path, required=True, help="output SVG path")
+    parser.add_argument("--font", default="Arial", help="unified font-family (default: Arial)")
+    parser.add_argument("--export-pdf", action="store_true",
+                        help="export an editable PDF alongside the SVG")
+    parser.add_argument("--export-pdf-final", action="store_true",
+                        help="export submission PDF with text converted to paths")
+    parser.add_argument("--export-pptx", action="store_true",
+                        help="export a 16:9 PPTX with the rendered figure embedded")
+    args = parser.parse_args()
+
+    if not args.template.exists():
+        print(f"Error: template not found: {args.template}", file=sys.stderr)
+        return 1
+    if not args.manifest.exists():
+        print(f"Error: manifest not found: {args.manifest}", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    manifest = load_manifest(args.manifest)
+
+    fill_placeholders(args.template, manifest, args.output)
+    normalize_fonts(args.output, args.font)
+
+    if args.export_pdf:
+        export_pdf(
+            args.output,
+            args.output.with_name(args.output.stem + "_editable.pdf"),
+            outline_text=False,
+        )
+    if args.export_pdf_final:
+        export_pdf(
+            args.output,
+            args.output.with_name(args.output.stem + "_submission.pdf"),
+            outline_text=True,
+        )
+    if args.export_pptx:
+        export_pptx(args.output, args.output.with_suffix(".pptx"))
+
+    print(f"\nAll done. Main output: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -237,14 +238,18 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                       file=sys.stderr)
                 continue
 
-            for placeholder in placeholders:
+            # `_find_placeholders` may return multiple hits for one panel_id;
+            # suffix the wrapper id with the 1-based index so the output SVG
+            # never has duplicate ids (which break selectors / a11y / editor
+            # validation).
+            for idx, placeholder in enumerate(placeholders, start=1):
                 parent = placeholder.getparent()
                 if parent is None:
                     continue
                 wrapper = etree.SubElement(
                     parent, f"{SVG_TAG}g",
                     attrib={
-                        "id": f"panel-{panel_id}",
+                        "id": f"panel-{panel_id}-{idx}",
                         "transform": placeholder.get("transform", ""),
                     },
                 )
@@ -259,14 +264,14 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
             # drive letters, and `xmllint`/browser SVG renderers that treat
             # naked paths as relative.
             href_uri = element_full_path.resolve().as_uri()
-            for placeholder in placeholders:
+            for idx, placeholder in enumerate(placeholders, start=1):
                 parent = placeholder.getparent()
                 if parent is None:
                     continue
                 etree.SubElement(
                     parent, f"{SVG_TAG}image",
                     attrib={
-                        "id": f"panel-{panel_id}",
+                        "id": f"panel-{panel_id}-{idx}",
                         "x": placeholder.get("x", "0"),
                         "y": placeholder.get("y", "0"),
                         "width": placeholder.get("width", "100"),
@@ -303,7 +308,12 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
             for r in used_attribution
         })
         attr_text = "Adapted from: " + "; ".join(attr_lines)
-        viewbox = (root.get("viewBox") or "0 0 1600 1000").split()
+        # Per SVG spec, viewBox values are separated by whitespace, comma, or
+        # both (e.g. "0, 0, 1600, 1000" is valid). `.split()` only handles
+        # whitespace and would either silently fall back to defaults or, worse,
+        # raise ValueError on `float("1600,")`. Use a comma+whitespace regex.
+        viewbox_raw = (root.get("viewBox") or "0 0 1600 1000").strip()
+        viewbox = [v for v in re.split(r"[\s,]+", viewbox_raw) if v]
         canvas_w = float(viewbox[2]) if len(viewbox) >= 4 else 1600.0
         canvas_h = float(viewbox[3]) if len(viewbox) >= 4 else 1000.0
         attr_node = etree.SubElement(

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -211,10 +211,18 @@ def _namespace_subtree_ids(wrapper: etree._Element, prefix: str) -> None:
     its `<defs>` / `<clipPath>` / `<mask>` / `<linearGradient>` etc. produces
     duplicate `id`s and `url(#xxx)` references that bind to whichever copy XML
     visits first — wrong renders, broken selectors. We rewrite both sides.
+
+    The wrapper element itself is skipped: its id was set to `prefix` by the
+    caller, and re-prefixing would produce e.g. `panel-a-1-panel-a-1`, breaking
+    every downstream `dom_set` selector that targets panels by their expected
+    id.
     """
     # 1) Collect ids and rewrite the id attribute itself.
+    #    Skip the wrapper itself (its id is the caller-supplied prefix).
     id_map: dict[str, str] = {}
     for elem in wrapper.iter():
+        if elem is wrapper:
+            continue
         old_id = elem.get("id")
         if old_id:
             new_id = f"{prefix}-{old_id}"
@@ -399,13 +407,20 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
         # raise ValueError on `float("1600,")`. Use a comma+whitespace regex.
         viewbox_raw = (root.get("viewBox") or "0 0 1600 1000").strip()
         viewbox = [v for v in re.split(r"[\s,]+", viewbox_raw) if v]
+        # viewBox = "min-x min-y width height". Bottom-right is at
+        # (min-x + width, min-y + height); not (width, height) when origin
+        # is non-zero. Templates with a translated origin (e.g.
+        # `viewBox="100 200 1600 1000"`) would otherwise place the
+        # caption inside the visible area but offset from the corner.
+        origin_x = float(viewbox[0]) if len(viewbox) >= 4 else 0.0
+        origin_y = float(viewbox[1]) if len(viewbox) >= 4 else 0.0
         canvas_w = float(viewbox[2]) if len(viewbox) >= 4 else 1600.0
         canvas_h = float(viewbox[3]) if len(viewbox) >= 4 else 1000.0
         attr_node = etree.SubElement(
             root, f"{SVG_TAG}text",
             attrib={
-                "x": str(canvas_w - 10),
-                "y": str(canvas_h - 5),
+                "x": str(origin_x + canvas_w - 10),
+                "y": str(origin_y + canvas_h - 5),
                 "text-anchor": "end",
                 "font-size": "8",
                 "fill": "#888",

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -53,44 +53,97 @@ def load_manifest(manifest_path: Path) -> dict:
     return yaml.safe_load(manifest_path.read_text())
 
 
+# Same shape that library_tools.load_unified_index() emits for legacy YAML rows.
+_LEGACY_CATEGORIES = (
+    "cells", "molecules", "organelles", "tissues",
+    "organs", "equipment", "pathways", "arrows",
+)
+
+
+def _scan_legacy_yaml(value: str, library_root: Path) -> dict | None:
+    """Walk per-category _index.yaml files for a `manual-...` style ID.
+
+    library_tools.search emits IDs like `manual-cells-treg-flat-v1` for rows
+    registered through the legacy YAML path; without this fallback, those IDs
+    can't be resolved here, even though the same ID renders in `search`.
+    """
+    if not value.startswith("manual-"):
+        return None
+    for category in _LEGACY_CATEGORIES:
+        yaml_index = library_root / category / "_index.yaml"
+        if not yaml_index.exists():
+            continue
+        try:
+            data = yaml.safe_load(yaml_index.read_text()) or {"elements": []}
+        except Exception:
+            continue
+        for entry in data.get("elements", []):
+            file_stem = (entry.get("file") or "").replace(".svg", "")
+            fid = f"manual-{category}-{file_stem}"
+            if fid == value:
+                return {
+                    "id": fid,
+                    "_category": category,
+                    "_file": entry.get("file", ""),
+                    "license": entry.get("license", "research-use-only"),
+                    "source_name": entry.get("provider", "manual"),
+                    "attribution_required": False,
+                }
+    return None
+
+
 def resolve_element_path(value: str, library_root: Path) -> Path:
     """Map a manifest value to an actual on-disk file.
 
     Disambiguation:
       * "/" in value or extension in {.svg, .png, .emf}  ->  treated as a
         path relative to `library_root`.
-      * else  ->  treated as a unified-index ID, looked up in
-        library_root/library/index.json.
+      * starts with "manual-"                             ->  legacy YAML lookup.
+      * else                                              ->  unified-index ID
+        lookup in library_root/library/index.json.
     """
     if "/" in value or value.lower().endswith((".svg", ".png", ".emf")):
         return library_root / value
 
+    legacy = _scan_legacy_yaml(value, library_root)
+    if legacy is not None:
+        return library_root / legacy["_category"] / legacy["_file"]
+
     json_index = library_root / "library" / "index.json"
-    if not json_index.exists():
-        return library_root / value
-    try:
-        records: list[dict] = json.loads(json_index.read_text())
-        for r in records:
-            if r.get("id") == value:
-                return library_root / "library" / r["file"]
-    except Exception:
-        pass
+    if json_index.exists():
+        try:
+            records: list[dict] = json.loads(json_index.read_text())
+            for r in records:
+                if r.get("id") == value:
+                    return library_root / "library" / r["file"]
+        except Exception:
+            pass
     return library_root / value
 
 
 def lookup_attribution(value: str, library_root: Path) -> dict | None:
-    """If `value` is a unified-index ID for a CC-BY element, return its record."""
+    """If `value` is a CC-BY element ID, return its record.
+
+    Walks both the unified `library/index.json` and the legacy per-category
+    YAMLs (legacy entries are CC0-equivalent by convention, so they never
+    return non-None here, but the symmetric lookup keeps the resolution model
+    consistent).
+    """
     if "/" in value or value.lower().endswith((".svg", ".png", ".emf")):
         return None
     json_index = library_root / "library" / "index.json"
-    if not json_index.exists():
-        return None
-    try:
-        for r in json.loads(json_index.read_text()):
-            if r.get("id") == value and r.get("attribution_required"):
-                return r
-    except Exception:
-        return None
+    if json_index.exists():
+        try:
+            for r in json.loads(json_index.read_text()):
+                if r.get("id") == value and r.get("attribution_required"):
+                    return r
+        except Exception:
+            pass
+    # Legacy YAML rows are not flagged attribution_required; if that ever
+    # changes, _scan_legacy_yaml's record carries the field.
+    legacy = _scan_legacy_yaml(value, library_root)
+    if legacy and legacy.get("attribution_required"):
+        return legacy
     return None
 
 
@@ -249,15 +302,32 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
 
 
 def normalize_fonts(svg_path: Path, font_family: str) -> None:
-    """Force every text-bearing element to use one font-family."""
+    """Force every text-bearing element to use one font-family.
+
+    Three passes:
+      1. set font-family on the root <svg> so inheritance picks it up;
+      2. rewrite any explicit `font-family=...` attribute or `style=...;font-family:...`;
+      3. for `<text>` / `<tspan>` that declare neither, set an explicit
+         `font-family` so merged CC0 subtrees (whose own <svg> root we
+         dropped) don't fall back to the UA default.
+    """
     tree = etree.parse(str(svg_path))
     root = tree.getroot()
 
     count = 0
+    # (1) root inheritance.
+    if root.get("font-family") != font_family:
+        root.set("font-family", font_family)
+        count += 1
+
+    text_tags = {f"{SVG_TAG}text", f"{SVG_TAG}tspan"}
     for elem in root.iter():
-        if elem.get("font-family"):
+        # (2) rewrite explicit attribute.
+        if elem.get("font-family") and elem.get("font-family") != font_family:
             elem.set("font-family", font_family)
             count += 1
+
+        # (2) rewrite within style="...".
         style = elem.get("style", "")
         if "font-family" in style:
             parts: list[str] = []
@@ -269,8 +339,34 @@ def normalize_fonts(svg_path: Path, font_family: str) -> None:
             elem.set("style", ";".join(parts))
             count += 1
 
+        # (3) explicitly set on text-bearing elements that have nothing.
+        if (elem.tag in text_tags
+                and not elem.get("font-family")
+                and "font-family" not in (elem.get("style") or "")):
+            elem.set("font-family", font_family)
+            count += 1
+
     tree.write(str(svg_path), xml_declaration=True, encoding="utf-8")
     print(f"[font] normalized {count} elements -> {font_family}")
+
+
+def _run_inkscape(cmd: list[str], purpose: str) -> bool:
+    """Run an Inkscape CLI invocation; return False (don't crash) on failure."""
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+        return True
+    except FileNotFoundError:
+        print(f"Warning: Inkscape CLI not found on PATH; skipping {purpose}.",
+              file=sys.stderr)
+        print("  Install Inkscape >= 1.2 from https://inkscape.org/", file=sys.stderr)
+        return False
+    except subprocess.CalledProcessError as exc:
+        stderr_tail = (exc.stderr or b"").decode("utf-8", errors="replace")[-400:]
+        print(f"Warning: Inkscape failed during {purpose}: {exc.returncode}",
+              file=sys.stderr)
+        if stderr_tail.strip():
+            print(f"  stderr: {stderr_tail.strip()}", file=sys.stderr)
+        return False
 
 
 def export_pdf(svg_path: Path, pdf_path: Path, outline_text: bool = False) -> None:
@@ -282,8 +378,8 @@ def export_pdf(svg_path: Path, pdf_path: Path, outline_text: bool = False) -> No
         f"--export-text-to-path={'true' if outline_text else 'false'}",
         f"--export-filename={pdf_path}",
     ]
-    subprocess.run(cmd, check=True, capture_output=True)
-    print(f"[export] PDF: {pdf_path}")
+    if _run_inkscape(cmd, f"PDF export -> {pdf_path}"):
+        print(f"[export] PDF: {pdf_path}")
 
 
 def export_pptx(svg_path: Path, pptx_path: Path) -> None:
@@ -298,27 +394,33 @@ def export_pptx(svg_path: Path, pptx_path: Path) -> None:
         return
 
     png_temp = svg_path.with_suffix(".tmp.png")
-    subprocess.run([
-        "inkscape", str(svg_path),
-        "--export-type=png",
-        "--export-dpi=300",
-        f"--export-filename={png_temp}",
-    ], check=True, capture_output=True)
-
-    prs = Presentation()
-    prs.slide_width = Inches(13.333)  # 16:9
-    prs.slide_height = Inches(7.5)
-    blank_layout = prs.slide_layouts[6]
-    slide = prs.slides.add_slide(blank_layout)
-    slide.shapes.add_picture(
-        str(png_temp),
-        left=Inches(0.5), top=Inches(0.5),
-        width=Inches(12.333), height=Inches(6.5),
+    rendered = _run_inkscape(
+        [
+            "inkscape", str(svg_path),
+            "--export-type=png",
+            "--export-dpi=300",
+            f"--export-filename={png_temp}",
+        ],
+        "PNG raster for PPTX",
     )
+    if not rendered:
+        return
 
-    prs.save(str(pptx_path))
-    png_temp.unlink(missing_ok=True)
-    print(f"[export] PPTX: {pptx_path}")
+    try:
+        prs = Presentation()
+        prs.slide_width = Inches(13.333)  # 16:9
+        prs.slide_height = Inches(7.5)
+        blank_layout = prs.slide_layouts[6]
+        slide = prs.slides.add_slide(blank_layout)
+        slide.shapes.add_picture(
+            str(png_temp),
+            left=Inches(0.5), top=Inches(0.5),
+            width=Inches(12.333), height=Inches(6.5),
+        )
+        prs.save(str(pptx_path))
+        print(f"[export] PPTX: {pptx_path}")
+    finally:
+        png_temp.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -49,8 +49,13 @@ XLINK_HREF = "{http://www.w3.org/1999/xlink}href"
 
 
 def load_manifest(manifest_path: Path) -> dict:
-    """Load the YAML manifest as a plain dict."""
-    return yaml.safe_load(manifest_path.read_text())
+    """Load the YAML manifest as a plain dict.
+
+    yaml.safe_load returns None for an empty / comment-only file; coerce to
+    an empty dict so downstream `manifest.get(...)` calls don't blow up with
+    AttributeError.
+    """
+    return yaml.safe_load(manifest_path.read_text()) or {}
 
 
 # Same shape that library_tools.load_unified_index() emits for legacy YAML rows.
@@ -122,28 +127,48 @@ def resolve_element_path(value: str, library_root: Path) -> Path:
 
 
 def lookup_attribution(value: str, library_root: Path) -> dict | None:
-    """If `value` is a CC-BY element ID, return its record.
+    """If `value` references a CC-BY element, return its record.
 
-    Walks both the unified `library/index.json` and the legacy per-category
-    YAMLs (legacy entries are CC0-equivalent by convention, so they never
-    return non-None here, but the symmetric lookup keeps the resolution model
-    consistent).
+    Resolves both shapes:
+      * unified-index ID  ->  match `r["id"] == value`
+      * relative path     ->  match `<library_root>/library/<r["file"]>`
+                              against the resolved manifest path; this covers
+                              the case where a user references a Reactome /
+                              Servier asset by path instead of ID.
+
+    Walks the unified `library/index.json` and the legacy per-category YAMLs.
+    Legacy YAML rows aren't currently flagged attribution_required, but the
+    symmetric scan keeps the resolution model consistent if that changes.
     """
-    if "/" in value or value.lower().endswith((".svg", ".png", ".emf")):
-        return None
     json_index = library_root / "library" / "index.json"
+
+    # ID branch.
+    if not ("/" in value or value.lower().endswith((".svg", ".png", ".emf"))):
+        if json_index.exists():
+            try:
+                for r in json.loads(json_index.read_text()):
+                    if r.get("id") == value and r.get("attribution_required"):
+                        return r
+            except Exception:
+                pass
+        legacy = _scan_legacy_yaml(value, library_root)
+        if legacy and legacy.get("attribution_required"):
+            return legacy
+        return None
+
+    # Path branch: resolve and reverse-lookup against the unified index by
+    # comparing against the on-disk path each record points at.
+    target = (library_root / value).resolve()
     if json_index.exists():
         try:
             for r in json.loads(json_index.read_text()):
-                if r.get("id") == value and r.get("attribution_required"):
+                if not r.get("attribution_required"):
+                    continue
+                rec_path = (library_root / "library" / r["file"]).resolve()
+                if rec_path == target:
                     return r
         except Exception:
             pass
-    # Legacy YAML rows are not flagged attribution_required; if that ever
-    # changes, _scan_legacy_yaml's record carries the field.
-    legacy = _scan_legacy_yaml(value, library_root)
-    if legacy and legacy.get("attribution_required"):
-        return legacy
     return None
 
 
@@ -229,6 +254,11 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                     wrapper.append(copy.deepcopy(child))
                 parent.remove(placeholder)
         else:
+            # Use a file:// URI rather than a bare filesystem path so the
+            # href stays valid across spaces in path components, Windows
+            # drive letters, and `xmllint`/browser SVG renderers that treat
+            # naked paths as relative.
+            href_uri = element_full_path.resolve().as_uri()
             for placeholder in placeholders:
                 parent = placeholder.getparent()
                 if parent is None:
@@ -241,7 +271,7 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                         "y": placeholder.get("y", "0"),
                         "width": placeholder.get("width", "100"),
                         "height": placeholder.get("height", "100"),
-                        XLINK_HREF: str(element_full_path),
+                        XLINK_HREF: href_uri,
                     },
                 )
                 parent.remove(placeholder)

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -232,6 +232,7 @@ def _namespace_subtree_ids(wrapper: etree._Element, prefix: str) -> None:
         return new
 
     # 2) Rewrite reference attributes & style values.
+    style_tag = f"{SVG_TAG}style"
     for elem in wrapper.iter():
         for attr in _REF_ATTRS:
             val = elem.get(attr)
@@ -248,6 +249,12 @@ def _namespace_subtree_ids(wrapper: etree._Element, prefix: str) -> None:
         style = elem.get("style")
         if style and "url(" in style:
             elem.set("style", _rewrite_value(style))
+        # `<style>…</style>` text nodes also carry CSS rules with url(#…)
+        # references that many SVG exporters emit (Inkscape, Affinity, etc.).
+        # Without rewriting these, an SVG with stylesheet-bound clip-paths
+        # gets cross-bound to the wrong copy when the same source is reused.
+        if elem.tag == style_tag and elem.text and "url(" in elem.text:
+            elem.text = _rewrite_value(elem.text)
 
 
 def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) -> None:
@@ -276,8 +283,10 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
             continue
 
         attr_record = lookup_attribution(element_value, library_root)
-        if attr_record is not None:
-            used_attribution.append(attr_record)
+        # Track whether anything actually got inserted onto the canvas; we
+        # only credit attribution after a successful fill so a failed parse
+        # / missing placeholder / continue branch can't pollute the caption.
+        inserted_any = False
 
         placeholders = _find_placeholders(root, panel_id)
         if not placeholders:
@@ -321,6 +330,7 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                 insert_at = list(parent).index(placeholder)
                 parent.remove(placeholder)
                 parent.insert(insert_at, wrapper)
+                inserted_any = True
         else:
             # Use a file:// URI rather than a bare filesystem path so the
             # href stays valid across spaces in path components, Windows
@@ -331,20 +341,30 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                 parent = placeholder.getparent()
                 if parent is None:
                     continue
-                image_elem = etree.Element(
-                    f"{SVG_TAG}image",
-                    attrib={
-                        "id": f"panel-{panel_id}-{idx}",
-                        "x": placeholder.get("x", "0"),
-                        "y": placeholder.get("y", "0"),
-                        "width": placeholder.get("width", "100"),
-                        "height": placeholder.get("height", "100"),
-                        XLINK_HREF: href_uri,
-                    },
-                )
+                # Carry placeholder's `transform` so PNG/JPG/EMF land in the
+                # same spot the SVG branch would: scale / rotate / translate
+                # set on the placeholder all apply to the resulting <image>.
+                image_attrib = {
+                    "id": f"panel-{panel_id}-{idx}",
+                    "x": placeholder.get("x", "0"),
+                    "y": placeholder.get("y", "0"),
+                    "width": placeholder.get("width", "100"),
+                    "height": placeholder.get("height", "100"),
+                    XLINK_HREF: href_uri,
+                }
+                ph_transform = placeholder.get("transform")
+                if ph_transform:
+                    image_attrib["transform"] = ph_transform
+                image_elem = etree.Element(f"{SVG_TAG}image", attrib=image_attrib)
                 insert_at = list(parent).index(placeholder)
                 parent.remove(placeholder)
                 parent.insert(insert_at, image_elem)
+                inserted_any = True
+
+        # Only count this asset toward the figure's attribution once at
+        # least one placeholder was actually filled in.
+        if inserted_any and attr_record is not None:
+            used_attribution.append(attr_record)
 
         print(f"[fill] panel {panel_id} <- {element_value}")
 

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -195,6 +195,61 @@ def _suspicious_id(panel_id: str) -> bool:
     return any(c in panel_id for c in ('"', "\n", "\r"))
 
 
+# Attributes that may carry a `url(#...)` reference or a bare `#id`.
+_REF_ATTRS = (
+    "href", "{http://www.w3.org/1999/xlink}href",
+    "clip-path", "mask", "filter",
+    "fill", "stroke",
+    "marker-start", "marker-mid", "marker-end",
+)
+
+
+def _namespace_subtree_ids(wrapper: etree._Element, prefix: str) -> None:
+    """Prefix every `id` and same-document reference inside `wrapper`.
+
+    When the same source SVG is dropped into multiple placeholders, deep-copying
+    its `<defs>` / `<clipPath>` / `<mask>` / `<linearGradient>` etc. produces
+    duplicate `id`s and `url(#xxx)` references that bind to whichever copy XML
+    visits first — wrong renders, broken selectors. We rewrite both sides.
+    """
+    # 1) Collect ids and rewrite the id attribute itself.
+    id_map: dict[str, str] = {}
+    for elem in wrapper.iter():
+        old_id = elem.get("id")
+        if old_id:
+            new_id = f"{prefix}-{old_id}"
+            id_map[old_id] = new_id
+            elem.set("id", new_id)
+    if not id_map:
+        return
+
+    def _rewrite_value(value: str) -> str:
+        new = value
+        for old_id, new_id in id_map.items():
+            new = new.replace(f"url(#{old_id})", f"url(#{new_id})")
+            new = new.replace(f'url("#{old_id}")', f'url("#{new_id}")')
+            new = new.replace(f"url('#{old_id}')", f"url('#{new_id}')")
+        return new
+
+    # 2) Rewrite reference attributes & style values.
+    for elem in wrapper.iter():
+        for attr in _REF_ATTRS:
+            val = elem.get(attr)
+            if not val:
+                continue
+            # Bare `#fragment` is an in-document reference; rewrite as a whole.
+            if val.startswith("#"):
+                old_id = val[1:]
+                if old_id in id_map:
+                    elem.set(attr, f"#{id_map[old_id]}")
+                continue
+            if "url(" in val:
+                elem.set(attr, _rewrite_value(val))
+        style = elem.get("style")
+        if style and "url(" in style:
+            elem.set("style", _rewrite_value(style))
+
+
 def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) -> None:
     """Write a filled SVG with element bodies + label text + attribution caption."""
     parser = etree.XMLParser(remove_blank_text=False)
@@ -241,15 +296,17 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
             # `_find_placeholders` may return multiple hits for one panel_id;
             # suffix the wrapper id with the 1-based index so the output SVG
             # never has duplicate ids (which break selectors / a11y / editor
-            # validation).
+            # validation). Inserting at the placeholder's original index
+            # preserves SVG document order = z-order.
             for idx, placeholder in enumerate(placeholders, start=1):
                 parent = placeholder.getparent()
                 if parent is None:
                     continue
-                wrapper = etree.SubElement(
-                    parent, f"{SVG_TAG}g",
+                wrapper_id = f"panel-{panel_id}-{idx}"
+                wrapper = etree.Element(
+                    f"{SVG_TAG}g",
                     attrib={
-                        "id": f"panel-{panel_id}-{idx}",
+                        "id": wrapper_id,
                         "transform": placeholder.get("transform", ""),
                     },
                 )
@@ -257,7 +314,13 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                 # SVG don't share node identity.
                 for child in elem_root:
                     wrapper.append(copy.deepcopy(child))
+                # Namespace inner ids+refs so multiple copies of the same
+                # source SVG don't produce id collisions or cross-bind
+                # `url(#…)` references to the wrong instance.
+                _namespace_subtree_ids(wrapper, wrapper_id)
+                insert_at = list(parent).index(placeholder)
                 parent.remove(placeholder)
+                parent.insert(insert_at, wrapper)
         else:
             # Use a file:// URI rather than a bare filesystem path so the
             # href stays valid across spaces in path components, Windows
@@ -268,8 +331,8 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                 parent = placeholder.getparent()
                 if parent is None:
                     continue
-                etree.SubElement(
-                    parent, f"{SVG_TAG}image",
+                image_elem = etree.Element(
+                    f"{SVG_TAG}image",
                     attrib={
                         "id": f"panel-{panel_id}-{idx}",
                         "x": placeholder.get("x", "0"),
@@ -279,7 +342,9 @@ def fill_placeholders(template_path: Path, manifest: dict, output_path: Path) ->
                         XLINK_HREF: href_uri,
                     },
                 )
+                insert_at = list(parent).index(placeholder)
                 parent.remove(placeholder)
+                parent.insert(insert_at, image_elem)
 
         print(f"[fill] panel {panel_id} <- {element_value}")
 

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -653,7 +653,12 @@ def extract_servier_pptx(target_root: Path, pptx_path: Path) -> list[dict]:
 
 
 def merge_index(target_root: Path, new_records: list[dict]) -> tuple[int, int]:
-    """Merge new records into library/index.json, dedupe by record id."""
+    """Merge new records into library/index.json, dedupe by record id.
+
+    Dedupes both against the on-disk index and within `new_records` itself —
+    a single batch can produce duplicates (e.g. a source's API paginates the
+    same item twice) and the downstream resolver assumes IDs are unique.
+    """
     index_path = target_root / "library" / "index.json"
     if index_path.exists():
         try:
@@ -666,8 +671,10 @@ def merge_index(target_root: Path, new_records: list[dict]) -> tuple[int, int]:
     existing_ids = {r["id"] for r in existing}
     added = 0
     for r in new_records:
-        if r["id"] not in existing_ids:
+        rid = r["id"]
+        if rid not in existing_ids:
             existing.append(r)
+            existing_ids.add(rid)  # also dedupe within this batch
             added += 1
     index_path.parent.mkdir(parents=True, exist_ok=True)
     index_path.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
@@ -753,7 +760,16 @@ def main() -> int:
     # a single, actionable message instead of partway through a source.
     _require_runtime_deps()
 
-    sources_to_run = list(SOURCES_META.keys()) if args.all else [args.source]
+    if args.all:
+        # --all is documented as "every non-manual source"; quietly drop the
+        # ones that need a user-supplied --pptx / --zip so the helpful
+        # "requires --xxx" stub doesn't spam the overnight log.
+        sources_to_run = [
+            s for s, meta in SOURCES_META.items()
+            if not meta.get("manual_download")
+        ]
+    else:
+        sources_to_run = [args.source]
 
     for s in sources_to_run:
         try:

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -479,12 +479,19 @@ def ingest_nih_bioart_zip(target_root: Path, zip_path: Path) -> list[dict]:
             print(f"  Found {len(members)} usable files in {zip_path.name}")
             for entry in tqdm(members, desc="  Extracting", unit="file"):
                 ext = entry.rsplit(".", 1)[-1].lower()
+                # Slugify the full ZIP-relative path (sans extension) so two
+                # members sharing a stem under different directories don't
+                # silently overwrite each other on disk while merge_index
+                # keeps only the first record's metadata. Same pattern as
+                # download_bioicons / download_reactome.
+                relpath_sans_ext = str(Path(entry).with_suffix(""))
+                item_slug = slugify(relpath_sans_ext.replace("/", "-"))
                 stem = Path(entry).stem
-                target_path = target_subdir / f"nihbioart-{slugify(stem)}.{ext}"
+                target_path = target_subdir / f"nihbioart-{item_slug}.{ext}"
                 with zf.open(entry) as src, open(target_path, "wb") as dst:
                     dst.write(src.read())
                 rec = make_record(
-                    "nih_bioart", slugify(stem), stem.replace("_", " "), [],
+                    "nih_bioart", item_slug, stem.replace("_", " "), [],
                     file_relpath=str(target_path.relative_to(library_dir)),
                 )
                 records.append(rec)
@@ -608,10 +615,16 @@ def download_scidraw(target_root: Path, max_count: int | None = None) -> list[di
                 file_resp = requests.get(file_url, timeout=20)
                 if file_resp.status_code != 200:
                     continue
-                target_path = target_subdir / f"scidraw-{slugify(title)}.svg"
+                # SciDraw URLs are of the form /drawings/<id>; pages can
+                # share an h1 title (different artists, same subject), so
+                # slug-by-title alone collides on disk. Append the URL's
+                # drawing id as a stable unique suffix.
+                drawing_id = url.rstrip("/").rsplit("/", 1)[-1]
+                item_slug = slugify(f"{title}-{drawing_id}")
+                target_path = target_subdir / f"scidraw-{item_slug}.svg"
                 target_path.write_bytes(file_resp.content)
                 rec = make_record(
-                    "scidraw", slugify(title), title, ["neuroscience"],
+                    "scidraw", item_slug, title, ["neuroscience"],
                     file_relpath=str(target_path.relative_to(library_dir)),
                 )
                 records.append(rec)
@@ -651,12 +664,17 @@ def extract_servier_pptx(target_root: Path, pptx_path: Path) -> list[dict]:
                 ext = entry.rsplit(".", 1)[-1].lower()
                 if ext not in ("emf", "wmf", "png", "svg", "jpg", "jpeg"):
                     continue
+                # Same fix as ingest_nih_bioart_zip — distinct PPTX media
+                # entries with the same stem under different ppt/media/
+                # subpaths shouldn't collide on disk and lose metadata.
+                relpath_sans_ext = str(Path(entry).with_suffix(""))
+                item_slug = slugify(relpath_sans_ext.replace("/", "-"))
                 stem = Path(entry).stem
-                target_path = target_subdir / f"servier-{slugify(stem)}.{ext}"
+                target_path = target_subdir / f"servier-{item_slug}.{ext}"
                 with zf.open(entry) as src, open(target_path, "wb") as dst:
                     dst.write(src.read())
                 rec = make_record(
-                    "servier", slugify(stem), stem.replace("_", " "), [],
+                    "servier", item_slug, stem.replace("_", " "), [],
                     file_relpath=str(target_path.relative_to(library_dir)),
                 )
                 records.append(rec)

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -380,9 +380,15 @@ def download_phylopic(target_root: Path, max_count: int | None = None) -> list[d
             seen_ids.add(uuid)
 
             links = item.get("_links") or {}
-            vf = links.get("vectorFile") or links.get("sourceFile") or {}
+            # Only ingest from `vectorFile`. `sourceFile` may be a raster
+            # (PNG/JPEG) which would silently corrupt downstream tooling
+            # (etree.parse, cairosvg) when saved with a `.svg` extension.
+            # The library is SVG-only by design; raster fallbacks belong in
+            # a separate ingestion path.
+            vf = links.get("vectorFile") or {}
             href = vf.get("href")
-            if not href:
+            vf_type = (vf.get("type") or "").lower()
+            if not href or "svg" not in vf_type:
                 continue
 
             specific_node = links.get("specificNode") or {}
@@ -394,18 +400,24 @@ def download_phylopic(target_root: Path, max_count: int | None = None) -> list[d
             license_short = "CC0" if is_cc0 else "CC-BY"
             attribution = "" if is_cc0 else f"PhyloPic image by {contributor} (CC BY)"
 
+            # Use 12 hex chars instead of 8: at PhyloPic's ~12 000 records the
+            # birthday-paradox collision rate drops from ~1.7% (32-bit prefix)
+            # to ~3e-5 (48-bit prefix). The cost is a slightly longer ID/file
+            # name, which is fine.
+            uuid_short = uuid[:12]
+
             try:
                 # PhyloPic returns absolute URLs already; no urljoin needed.
                 file_resp = requests.get(href, timeout=20)
                 if file_resp.status_code != 200:
                     continue
-                target_path = target_subdir / f"phylopic-{uuid[:8]}-{slugify(name)}.svg"
+                target_path = target_subdir / f"phylopic-{uuid_short}-{slugify(name)}.svg"
                 target_path.write_bytes(file_resp.content)
             except Exception:
                 continue
 
             rec = make_record(
-                "phylopic", uuid[:8], name, ["silhouette"],
+                "phylopic", uuid_short, name, ["silhouette"],
                 file_relpath=str(target_path.relative_to(library_dir)),
                 license_override=license_short,
                 attribution_override=attribution,

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -257,11 +257,18 @@ def download_bioicons(target_root: Path) -> list[dict]:
             name = svg.stem.replace("_", " ").replace("-", " ")
             tags = [category_hint] if category_hint else []
 
-            tmp = make_record("bioicons", slugify(svg.stem), name, tags, file_relpath="")
+            # Slugify the full repo-relative path (sans extension) so two
+            # SVGs that share a stem under different categories end up with
+            # distinct ids/filenames. With only `slugify(svg.stem)` they'd
+            # collide on disk and `merge_index` would silently drop one.
+            relpath_sans_ext = str(relpath_in_repo.with_suffix(""))
+            item_slug = slugify(relpath_sans_ext.replace("/", "-"))
+
+            tmp = make_record("bioicons", item_slug, name, tags, file_relpath="")
             target_subdir = library_dir / tmp["category"]
             target_subdir.mkdir(parents=True, exist_ok=True)
 
-            target_path = target_subdir / f"bioicons-{slugify(svg.stem)}.svg"
+            target_path = target_subdir / f"bioicons-{item_slug}.svg"
             shutil.copy2(svg, target_path)
 
             tmp["file"] = str(target_path.relative_to(library_dir))
@@ -518,14 +525,21 @@ def download_reactome(target_root: Path) -> list[dict]:
     for svg in tqdm(svg_files, desc="  Importing", unit="icon"):
         try:
             name = svg.stem.replace("_", " ")
-            relpath_parts = svg.relative_to(repo_dir).parts
+            relpath_in_repo = svg.relative_to(repo_dir)
+            relpath_parts = relpath_in_repo.parts
             category_hint = relpath_parts[0] if len(relpath_parts) > 1 else ""
             tags = [category_hint] if category_hint else []
 
-            tmp = make_record("reactome", slugify(svg.stem), name, tags, file_relpath="")
+            # Slugify the full repo-relative path so two icons sharing a
+            # stem under different parent dirs don't collide on disk and
+            # silently get deduped to one row by merge_index().
+            relpath_sans_ext = str(relpath_in_repo.with_suffix(""))
+            item_slug = slugify(relpath_sans_ext.replace("/", "-"))
+
+            tmp = make_record("reactome", item_slug, name, tags, file_relpath="")
             target_subdir = library_dir / tmp["category"]
             target_subdir.mkdir(parents=True, exist_ok=True)
-            target_path = target_subdir / f"reactome-{slugify(svg.stem)}.svg"
+            target_path = target_subdir / f"reactome-{item_slug}.svg"
             shutil.copy2(svg, target_path)
             tmp["file"] = str(target_path.relative_to(library_dir))
             records.append(tmp)

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+"""
+download_cc0_seed.py — bootstrap a local scientific icon library from 6 public CC0 / CC-BY / public-domain sources.
+
+Sources:
+  1. BioIcons        — CC0          — ~1500 SVG, GitHub repo
+  2. PhyloPic v2     — CC0 / CC-BY  — ~12000 silhouettes, REST API
+  3. NIH BioArt      — Public Dom.  — ~2500 illustrations, MANUAL ZIP DROP
+                                       (the live site is now a Next.js SPA, no server-rendered HTML
+                                        and no public REST endpoint, so a HTTP scrape no longer works)
+  4. Reactome Icons  — CC BY 4.0    — ~500 SVG, GitHub repo
+  5. SciDraw         — CC0          — ~700 SVG, webscrape (Janelia)
+  6. Servier Med Art — CC BY 3.0    — ~3000 SVG/EMF, MANUAL PPTX DROP
+
+Dependencies:
+  pip install requests beautifulsoup4 lxml tqdm pyyaml
+  (python-pptx NOT required: Servier ingestion uses stdlib `zipfile`)
+
+Usage:
+  # Run every source that does not need a manual file
+  python download_cc0_seed.py --all --target ~/sci-illustration-library
+
+  # One source only
+  python download_cc0_seed.py --source bioicons
+
+  # Cap PhyloPic / SciDraw page count
+  python download_cc0_seed.py --source phylopic --max-per-source 500
+
+  # Servier requires a manually downloaded PPTX from https://smart.servier.com
+  python download_cc0_seed.py --source servier --pptx ./servier-anatomy.pptx
+
+  # NIH BioArt requires a manually downloaded ZIP from
+  # https://bioart.niaid.nih.gov/  (use the in-page "Download" buttons)
+  python download_cc0_seed.py --source nih_bioart --zip ./nih_bioart.zip
+
+  # Inspect the current library without downloading
+  python download_cc0_seed.py --summary-only --target ~/sci-illustration-library
+
+License tracking:
+  Every record in `library/index.json` carries a `license` field. CC-BY records
+  also get `attribution_required: true` and an `attribution` string, so
+  `library_tools.py attribution` can render figure-caption-ready text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from datetime import date
+from pathlib import Path
+
+# Third-party deps are imported lazily by `_require_runtime_deps()` so that
+# `--help` and `--summary-only` work even when nothing is installed yet.
+requests = None  # type: ignore[assignment]
+BeautifulSoup = None  # type: ignore[assignment]
+tqdm = None  # type: ignore[assignment]
+
+
+def _require_runtime_deps() -> None:
+    """Import third-party deps and bind them to module globals; fail-fast on miss."""
+    global requests, BeautifulSoup, tqdm
+    try:
+        import requests as _requests
+        from bs4 import BeautifulSoup as _BS
+        from tqdm import tqdm as _tqdm
+    except ImportError as exc:
+        print(f"[ERROR] missing dependency: {exc.name}", file=sys.stderr)
+        print("        pip install requests beautifulsoup4 lxml tqdm pyyaml", file=sys.stderr)
+        sys.exit(1)
+    requests = _requests  # type: ignore[assignment]
+    BeautifulSoup = _BS  # type: ignore[assignment]
+    tqdm = _tqdm  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Source registry
+# ---------------------------------------------------------------------------
+
+SOURCES_META: dict[str, dict] = {
+    "bioicons": {
+        "name": "BioIcons",
+        "url": "https://bioicons.com",
+        "repo": "https://github.com/duerrsimon/bioicons.git",
+        "license": "CC0",
+        "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "attribution_required": False,
+        "expected_count": 1500,
+    },
+    "phylopic": {
+        "name": "PhyloPic",
+        "url": "https://www.phylopic.org",
+        "api": "https://api.phylopic.org",
+        "license": "CC0/CC-BY",  # per-image
+        "license_url": "https://www.phylopic.org/about",
+        "attribution_required": "per_image",
+        "expected_count": 12000,
+    },
+    "nih_bioart": {
+        "name": "NIH BioArt (NIAID)",
+        "url": "https://bioart.niaid.nih.gov",
+        "license": "Public Domain",
+        "license_url": "https://www.nih.gov/about-nih/nih-image-gallery",
+        "attribution_required": False,
+        "expected_count": 2500,
+        "manual_download": True,
+    },
+    "reactome": {
+        "name": "Reactome Icon Library",
+        "url": "https://reactome.org/icon-lib",
+        "repo": "https://github.com/reactome/icon-lib.git",
+        "license": "CC BY 4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "attribution_required": True,
+        "attribution": "Reactome Icon Library, CC BY 4.0",
+        "expected_count": 500,
+    },
+    "scidraw": {
+        "name": "SciDraw",
+        "url": "https://scidraw.io",
+        "license": "CC0",
+        "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "attribution_required": False,
+        "expected_count": 700,
+    },
+    "servier": {
+        "name": "Servier Medical Art",
+        "url": "https://smart.servier.com",
+        "license": "CC BY 3.0",
+        "license_url": "https://creativecommons.org/licenses/by/3.0/",
+        "attribution_required": True,
+        "attribution": "Servier Medical Art (smart.servier.com), CC BY 3.0",
+        "expected_count": 3000,
+        "manual_download": True,
+    },
+}
+
+# Coarse name/tag → category mapping. Per-source post-processing may refine this.
+CATEGORY_KEYWORDS: dict[str, list[str]] = {
+    "cells/immune": ["t cell", "b cell", "macrophage", "dendritic", "neutrophil", "nk cell", "lymphocyte"],
+    "cells/cancer": ["tumor", "cancer", "metastasis", "carcinoma"],
+    "cells/blood": ["erythrocyte", "platelet", "rbc", "blood cell"],
+    "cells/neuron": ["neuron", "axon", "dendrite", "synapse", "glia"],
+    "cells/general": ["cell", "stem cell", "epithelial", "fibroblast"],
+    "molecules/protein": ["protein", "antibody", "receptor", "enzyme", "kinase"],
+    "molecules/nucleic_acid": ["dna", "rna", "mrna", "trna", "gene", "chromosome"],
+    "molecules/small": ["molecule", "metabolite", "drug", "lipid", "amino acid"],
+    "organelles": ["nucleus", "mitochondri", "ribosome", "endoplasmic", "golgi", "lysosome", "vesicle"],
+    "tissues": ["epithelium", "muscle tissue", "connective"],
+    "organs": ["heart", "liver", "lung", "brain", "kidney", "stomach", "pancreas", "intestine"],
+    "equipment/lab": ["pipette", "tube", "flask", "centrifuge", "microscope", "incubator", "well plate", "petri"],
+    "equipment/clinical": ["syringe", "stethoscope", "iv bag", "scalpel"],
+    "pathways": ["signaling", "pathway", "cascade"],
+    "arrows": ["arrow", "transition"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def slugify(text: str) -> str:
+    """Filesystem-safe slug, capped at 80 chars."""
+    s = re.sub(r"[^\w\-]+", "-", text.lower()).strip("-")
+    return s[:80] if s else "unnamed"
+
+
+def categorize(name: str, tags: list[str] | None) -> str:
+    """Best-effort category lookup from name + tags."""
+    haystack = " ".join([name] + (tags or [])).lower()
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        for kw in keywords:
+            if kw in haystack:
+                return category
+    return "uncategorized"
+
+
+def make_record(
+    source_id: str,
+    item_id: str,
+    name: str,
+    tags: list[str] | None,
+    file_relpath: str,
+    license_override: str | None = None,
+    attribution_override: str | None = None,
+) -> dict:
+    """Build a canonical index.json record for one element."""
+    src = SOURCES_META[source_id]
+    lic = license_override or src["license"]
+    attr_req = src.get("attribution_required", False)
+    if attr_req == "per_image":
+        attr_req = bool(attribution_override)
+
+    record: dict = {
+        "id": f"{source_id}-{item_id}",
+        "name": name,
+        "tags": tags or [],
+        "category": categorize(name, tags),
+        "source": source_id,
+        "source_name": src["name"],
+        "source_url": src["url"],
+        "license": lic,
+        "license_url": src["license_url"],
+        "attribution_required": bool(attr_req),
+        "file": file_relpath,
+        "added_at": str(date.today()),
+    }
+    if attr_req:
+        record["attribution"] = attribution_override or src.get("attribution", "")
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Source 1: BioIcons (git clone)
+# ---------------------------------------------------------------------------
+
+
+def download_bioicons(target_root: Path) -> list[dict]:
+    """Clone duerrsimon/bioicons and ingest every SVG it ships."""
+    print("\n[1/6] Downloading BioIcons (CC0)...")
+    src_meta = SOURCES_META["bioicons"]
+    target_dir = target_root / "_raw" / "bioicons"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = target_dir / "_repo"
+    if repo_dir.exists():
+        print(f"  [skip clone] {repo_dir} already exists, pulling...")
+        subprocess.run(["git", "-C", str(repo_dir), "pull", "--quiet"], check=False)
+    else:
+        result = subprocess.run(
+            ["git", "clone", "--depth=1", src_meta["repo"], str(repo_dir)],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            print(f"  [ERROR] git clone failed: {result.stderr[:200]}", file=sys.stderr)
+            return []
+
+    # bioicons keeps its SVGs under icons/<category>/.
+    icons_root = repo_dir / "icons"
+    if not icons_root.exists():
+        icons_root = repo_dir
+    svg_files = list(icons_root.rglob("*.svg"))
+    print(f"  Found {len(svg_files)} SVG files")
+
+    records: list[dict] = []
+    library_dir = target_root / "library"
+    for svg in tqdm(svg_files, desc="  Importing", unit="icon"):
+        try:
+            relpath_in_repo = svg.relative_to(icons_root)
+            category_hint = relpath_in_repo.parts[0] if len(relpath_in_repo.parts) > 1 else ""
+            name = svg.stem.replace("_", " ").replace("-", " ")
+            tags = [category_hint] if category_hint else []
+
+            tmp = make_record("bioicons", slugify(svg.stem), name, tags, file_relpath="")
+            target_subdir = library_dir / tmp["category"]
+            target_subdir.mkdir(parents=True, exist_ok=True)
+
+            target_path = target_subdir / f"bioicons-{slugify(svg.stem)}.svg"
+            shutil.copy2(svg, target_path)
+
+            tmp["file"] = str(target_path.relative_to(library_dir))
+            records.append(tmp)
+        except Exception as exc:
+            tqdm.write(f"  [skip] {svg.name}: {exc}")
+
+    print(f"  Imported {len(records)} icons")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Source 2: PhyloPic v2 REST API
+# ---------------------------------------------------------------------------
+#
+# Real-shape notes (verified against api.phylopic.org on 2026-05-03):
+#   * Pagination shape:  GET /images?build=<N>&page=<i>&embed_items=true
+#     - build       = API build number; api root advertises "?build=538" link.
+#     - embed_items = REQUIRED, else `_embedded` is absent and items can't be enumerated.
+#     - itemsPerPage is fixed by the server (currently 48). We honour totalPages.
+#   * Per-item shape:
+#     - item._links.vectorFile.href / sourceFile.href => ABSOLUTE URLs to SVG.
+#     - item._links.specificNode.title              => human-readable taxon name.
+#     - item._links.contributor.title               => contributor display name.
+#     - item._links.license.href                    => CC URI; presence of
+#       "publicdomain/zero" => CC0, else CC-BY (per PhyloPic policy).
+
+
+def _phylopic_build_id(api_root: str) -> int:
+    """Discover the current API build number by probing the root document."""
+    try:
+        resp = requests.get(f"{api_root}/", timeout=15)
+        resp.raise_for_status()
+        first_link = (resp.json().get("_links") or {}).get("self", {}).get("href", "")
+        match = re.search(r"build=(\d+)", first_link)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    # Fallback: use the api images endpoint which 308s with build=N in headers.
+    try:
+        resp = requests.get(f"{api_root}/images", timeout=15)
+        match = re.search(r"build=(\d+)", resp.url)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    return 0  # Many endpoints accept build=0 by 302-redirecting to current.
+
+
+def download_phylopic(target_root: Path, max_count: int | None = None) -> list[dict]:
+    """Page through PhyloPic v2 /images and ingest each silhouette."""
+    print("\n[2/6] Downloading PhyloPic (CC0/CC-BY)...")
+    src_meta = SOURCES_META["phylopic"]
+    api = src_meta["api"]
+
+    library_dir = target_root / "library"
+    target_subdir = library_dir / "tissues" / "phylopic"
+    target_subdir.mkdir(parents=True, exist_ok=True)
+
+    build_id = _phylopic_build_id(api)
+    if build_id == 0:
+        print("  [warn] could not discover build id; PhyloPic may reject requests", file=sys.stderr)
+
+    # Probe page 0 to learn totalPages.
+    try:
+        probe = requests.get(
+            f"{api}/images",
+            params={"build": build_id, "page": 0, "embed_items": "true"},
+            timeout=20,
+        )
+        probe.raise_for_status()
+        first = probe.json()
+    except Exception as exc:
+        print(f"  [skip] PhyloPic page 0 unreachable: {exc}", file=sys.stderr)
+        return []
+
+    total_pages = int(first.get("totalPages") or 1)
+    total_items = int(first.get("totalItems") or 0)
+    print(f"  PhyloPic reports build={build_id}, {total_items} items across {total_pages} pages")
+
+    records: list[dict] = []
+    seen_ids: set[str] = set()
+    pbar = tqdm(desc="  Downloading", unit="image",
+                total=min(total_items, max_count) if max_count else total_items)
+
+    page = 0
+    while page < total_pages:
+        if max_count is not None and len(records) >= max_count:
+            break
+        try:
+            if page == 0:
+                payload = first  # already fetched
+            else:
+                resp = requests.get(
+                    f"{api}/images",
+                    params={"build": build_id, "page": page, "embed_items": "true"},
+                    timeout=20,
+                )
+                if resp.status_code != 200:
+                    tqdm.write(f"  [api error] page={page} status={resp.status_code}")
+                    break
+                payload = resp.json()
+        except Exception as exc:
+            tqdm.write(f"  [api error] page={page}: {exc}")
+            break
+
+        items = (payload.get("_embedded") or {}).get("items") or []
+        if not items:
+            break
+
+        for item in items:
+            uuid = item.get("uuid") or ""
+            if not uuid or uuid in seen_ids:
+                continue
+            seen_ids.add(uuid)
+
+            links = item.get("_links") or {}
+            vf = links.get("vectorFile") or links.get("sourceFile") or {}
+            href = vf.get("href")
+            if not href:
+                continue
+
+            specific_node = links.get("specificNode") or {}
+            name = specific_node.get("title") or item.get("attribution") or uuid[:8]
+            contributor = (links.get("contributor") or {}).get("title", "unknown")
+
+            license_uri = (links.get("license") or {}).get("href", "")
+            is_cc0 = "publicdomain/zero" in license_uri or "publicdomain/mark" in license_uri
+            license_short = "CC0" if is_cc0 else "CC-BY"
+            attribution = "" if is_cc0 else f"PhyloPic image by {contributor} (CC BY)"
+
+            try:
+                # PhyloPic returns absolute URLs already; no urljoin needed.
+                file_resp = requests.get(href, timeout=20)
+                if file_resp.status_code != 200:
+                    continue
+                target_path = target_subdir / f"phylopic-{uuid[:8]}-{slugify(name)}.svg"
+                target_path.write_bytes(file_resp.content)
+            except Exception:
+                continue
+
+            rec = make_record(
+                "phylopic", uuid[:8], name, ["silhouette"],
+                file_relpath=str(target_path.relative_to(library_dir)),
+                license_override=license_short,
+                attribution_override=attribution,
+            )
+            records.append(rec)
+            pbar.update(1)
+            time.sleep(0.05)  # be polite
+
+            if max_count is not None and len(records) >= max_count:
+                break
+
+        page += 1
+
+    pbar.close()
+    print(f"  Imported {len(records)} silhouettes")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Source 3: NIH BioArt (manual ZIP drop — site is now a Next.js SPA)
+# ---------------------------------------------------------------------------
+
+
+def ingest_nih_bioart_zip(target_root: Path, zip_path: Path) -> list[dict]:
+    """Ingest a user-supplied ZIP archive from bioart.niaid.nih.gov.
+
+    The live site renders entirely client-side (Next.js) and exposes no public
+    REST endpoint, so a HTTP scrape returns no illustration links. The
+    expected workflow is: user opens https://bioart.niaid.nih.gov/, selects
+    illustrations and clicks the per-illustration "Download" button (or the
+    site's bulk-download where offered), zips the resulting folder, and points
+    this script at the archive.
+    """
+    print("\n[3/6] Ingesting NIH BioArt ZIP (Public Domain)...")
+    if not zip_path.exists():
+        print(f"  [skip] {zip_path} 不存在 / not found", file=sys.stderr)
+        print("  Workflow:", file=sys.stderr)
+        print("    1) Browse https://bioart.niaid.nih.gov/ and download wanted illustrations.", file=sys.stderr)
+        print("    2) Zip them into a single archive (any folder structure).", file=sys.stderr)
+        print("    3) Re-run: --source nih_bioart --zip <path>", file=sys.stderr)
+        return []
+
+    library_dir = target_root / "library"
+    target_subdir = library_dir / "uncategorized" / "nih_bioart"
+    target_subdir.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict] = []
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            wanted_exts = (".svg", ".ai", ".eps", ".png", ".jpg", ".jpeg")
+            members = [n for n in zf.namelist() if n.lower().endswith(wanted_exts)]
+            print(f"  Found {len(members)} usable files in {zip_path.name}")
+            for entry in tqdm(members, desc="  Extracting", unit="file"):
+                ext = entry.rsplit(".", 1)[-1].lower()
+                stem = Path(entry).stem
+                target_path = target_subdir / f"nihbioart-{slugify(stem)}.{ext}"
+                with zf.open(entry) as src, open(target_path, "wb") as dst:
+                    dst.write(src.read())
+                rec = make_record(
+                    "nih_bioart", slugify(stem), stem.replace("_", " "), [],
+                    file_relpath=str(target_path.relative_to(library_dir)),
+                )
+                records.append(rec)
+    except zipfile.BadZipFile as exc:
+        print(f"  [error] {zip_path.name} is not a valid ZIP: {exc}", file=sys.stderr)
+        return []
+
+    print(f"  Imported {len(records)} files")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Source 4: Reactome Icon Library (git clone)
+# ---------------------------------------------------------------------------
+
+
+def download_reactome(target_root: Path) -> list[dict]:
+    """Clone reactome/icon-lib and ingest every SVG."""
+    print("\n[4/6] Downloading Reactome Icon Library (CC BY 4.0)...")
+    src_meta = SOURCES_META["reactome"]
+    repo_dir = target_root / "_raw" / "reactome" / "_repo"
+    repo_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    if repo_dir.exists():
+        subprocess.run(["git", "-C", str(repo_dir), "pull", "--quiet"], check=False)
+    else:
+        result = subprocess.run(
+            ["git", "clone", "--depth=1", src_meta["repo"], str(repo_dir)],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            print(f"  [skip] git clone failed: {result.stderr[:200]}", file=sys.stderr)
+            return []
+
+    svg_files = list(repo_dir.rglob("*.svg"))
+    library_dir = target_root / "library"
+    records: list[dict] = []
+    for svg in tqdm(svg_files, desc="  Importing", unit="icon"):
+        try:
+            name = svg.stem.replace("_", " ")
+            relpath_parts = svg.relative_to(repo_dir).parts
+            category_hint = relpath_parts[0] if len(relpath_parts) > 1 else ""
+            tags = [category_hint] if category_hint else []
+
+            tmp = make_record("reactome", slugify(svg.stem), name, tags, file_relpath="")
+            target_subdir = library_dir / tmp["category"]
+            target_subdir.mkdir(parents=True, exist_ok=True)
+            target_path = target_subdir / f"reactome-{slugify(svg.stem)}.svg"
+            shutil.copy2(svg, target_path)
+            tmp["file"] = str(target_path.relative_to(library_dir))
+            records.append(tmp)
+        except Exception as exc:
+            tqdm.write(f"  [skip] {svg.name}: {exc}")
+
+    print(f"  Imported {len(records)} icons")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Source 5: SciDraw (webscrape — Janelia)
+# ---------------------------------------------------------------------------
+
+
+def download_scidraw(target_root: Path, max_count: int | None = None) -> list[dict]:
+    """Best-effort scrape of scidraw.io drawing pages.
+
+    SciDraw is a small static site, so listing-page scraping is reasonable.
+    If the site changes structure, this function logs and returns [] without
+    killing the rest of the pipeline.
+    """
+    print("\n[5/6] Downloading SciDraw (CC0)...")
+    base = "https://scidraw.io"
+
+    try:
+        resp = requests.get(
+            base, timeout=20,
+            headers={"User-Agent": "Mozilla/5.0 sci-pipeline/0.1"},
+        )
+        if resp.status_code != 200:
+            print("  [skip] SciDraw unreachable", file=sys.stderr)
+            return []
+        soup = BeautifulSoup(resp.text, "html.parser")
+    except Exception as exc:
+        print(f"  [skip] {exc}", file=sys.stderr)
+        return []
+
+    library_dir = target_root / "library"
+    target_subdir = library_dir / "cells" / "neuron" / "scidraw"
+    target_subdir.mkdir(parents=True, exist_ok=True)
+
+    drawings = soup.find_all("a", href=re.compile(r"/drawings/\d+"))
+    seen: set[str] = set()
+    records: list[dict] = []
+    pbar = tqdm(drawings, desc="  Downloading", unit="image")
+    try:
+        for a in pbar:
+            if max_count is not None and len(records) >= max_count:
+                break
+            url = f"{base}{a['href']}" if a["href"].startswith("/") else a["href"]
+            if url in seen:
+                continue
+            seen.add(url)
+            try:
+                detail = requests.get(url, timeout=15)
+                detail_soup = BeautifulSoup(detail.text, "html.parser")
+                title_el = detail_soup.find("h1") or detail_soup.find("title")
+                title = title_el.get_text(strip=True) if title_el else url.rsplit("/", 1)[-1]
+                dl = detail_soup.find("a", href=re.compile(r"\.svg$", re.I))
+                if not dl:
+                    continue
+                file_url = dl["href"]
+                if file_url.startswith("/"):
+                    file_url = base + file_url
+                file_resp = requests.get(file_url, timeout=20)
+                if file_resp.status_code != 200:
+                    continue
+                target_path = target_subdir / f"scidraw-{slugify(title)}.svg"
+                target_path.write_bytes(file_resp.content)
+                rec = make_record(
+                    "scidraw", slugify(title), title, ["neuroscience"],
+                    file_relpath=str(target_path.relative_to(library_dir)),
+                )
+                records.append(rec)
+                time.sleep(0.15)
+            except Exception:
+                continue
+    finally:
+        pbar.close()
+    print(f"  Imported {len(records)} drawings")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Source 6: Servier Medical Art (extract from manually-downloaded PPTX)
+# ---------------------------------------------------------------------------
+
+
+def extract_servier_pptx(target_root: Path, pptx_path: Path) -> list[dict]:
+    """Servier ships everything as a PowerPoint pack; ppt/media/ has the assets."""
+    print("\n[6/6] Extracting Servier Medical Art from PPTX...")
+    if not pptx_path.exists():
+        print(f"  [skip] {pptx_path} 不存在 / not found", file=sys.stderr)
+        print("  Workflow: download a PPTX pack from https://smart.servier.com,", file=sys.stderr)
+        print("            then re-run: --source servier --pptx <path>", file=sys.stderr)
+        return []
+
+    library_dir = target_root / "library"
+    target_subdir = library_dir / "_raw" / "servier"
+    target_subdir.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict] = []
+    try:
+        with zipfile.ZipFile(pptx_path) as zf:
+            media = [n for n in zf.namelist() if n.startswith("ppt/media/")]
+            print(f"  Found {len(media)} media files in PPTX")
+            for entry in tqdm(media, desc="  Extracting", unit="file"):
+                ext = entry.rsplit(".", 1)[-1].lower()
+                if ext not in ("emf", "wmf", "png", "svg", "jpg", "jpeg"):
+                    continue
+                stem = Path(entry).stem
+                target_path = target_subdir / f"servier-{slugify(stem)}.{ext}"
+                with zf.open(entry) as src, open(target_path, "wb") as dst:
+                    dst.write(src.read())
+                rec = make_record(
+                    "servier", slugify(stem), stem.replace("_", " "), [],
+                    file_relpath=str(target_path.relative_to(library_dir)),
+                )
+                records.append(rec)
+    except zipfile.BadZipFile as exc:
+        print(f"  [error] {pptx_path.name} is not a valid PPTX/ZIP: {exc}", file=sys.stderr)
+        return []
+    except Exception as exc:
+        print(f"  [error] {exc}", file=sys.stderr)
+        return []
+
+    print(f"  Extracted {len(records)} files")
+    print("  Note: EMF/WMF need LibreOffice or Inkscape conversion before they")
+    print("        render in most non-Office tooling.")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Index merge & summary
+# ---------------------------------------------------------------------------
+
+
+def merge_index(target_root: Path, new_records: list[dict]) -> tuple[int, int]:
+    """Merge new records into library/index.json, dedupe by record id."""
+    index_path = target_root / "library" / "index.json"
+    if index_path.exists():
+        try:
+            existing: list[dict] = json.loads(index_path.read_text())
+        except json.JSONDecodeError:
+            print(f"  [warn] {index_path} is malformed; rewriting from scratch", file=sys.stderr)
+            existing = []
+    else:
+        existing = []
+    existing_ids = {r["id"] for r in existing}
+    added = 0
+    for r in new_records:
+        if r["id"] not in existing_ids:
+            existing.append(r)
+            added += 1
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
+    return added, len(existing)
+
+
+def print_summary(target_root: Path) -> None:
+    """Group + count library/index.json by source / category / license."""
+    index_path = target_root / "library" / "index.json"
+    if not index_path.exists():
+        print(f"\n[summary] {index_path} not found — library is empty.")
+        return
+    try:
+        records: list[dict] = json.loads(index_path.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"[summary] {index_path} malformed: {exc}", file=sys.stderr)
+        return
+
+    by_source: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+    by_license: dict[str, int] = {}
+    for r in records:
+        by_source[r.get("source", "?")] = by_source.get(r.get("source", "?"), 0) + 1
+        by_category[r.get("category", "?")] = by_category.get(r.get("category", "?"), 0) + 1
+        by_license[r.get("license", "?")] = by_license.get(r.get("license", "?"), 0) + 1
+
+    print(f"\n{'=' * 60}")
+    print(f"Library overview  (root: {target_root})")
+    print(f"{'=' * 60}")
+    print(f"\nTotal: {len(records)}\n")
+    print("By source:")
+    for s, n in sorted(by_source.items(), key=lambda x: -x[1]):
+        print(f"  {s:20s} {n:>6d}")
+    print("\nBy category (top 12):")
+    for c, n in sorted(by_category.items(), key=lambda x: -x[1])[:12]:
+        print(f"  {c:25s} {n:>6d}")
+    print("\nBy license:")
+    for lic, n in sorted(by_license.items(), key=lambda x: -x[1]):
+        print(f"  {lic:20s} {n:>6d}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Download CC0/CC-BY scientific icons from 6 public sources",
+    )
+    parser.add_argument("--target", default="~/sci-illustration-library",
+                        help="Local library root (default: ~/sci-illustration-library)")
+    parser.add_argument("--source", choices=list(SOURCES_META.keys()),
+                        help="Run a single source")
+    parser.add_argument("--all", action="store_true", help="Run every non-manual source")
+    parser.add_argument("--max-per-source", type=int, default=None,
+                        help="Cap downloads per source (PhyloPic / SciDraw)")
+    parser.add_argument("--pptx", type=str, default=None,
+                        help="Servier PPTX path (only with --source servier)")
+    parser.add_argument("--zip", type=str, default=None,
+                        help="NIH BioArt ZIP path (only with --source nih_bioart)")
+    parser.add_argument("--summary-only", action="store_true",
+                        help="Print library stats without downloading")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    target_root = Path(args.target).expanduser().resolve()
+    target_root.mkdir(parents=True, exist_ok=True)
+    (target_root / "library").mkdir(exist_ok=True)
+
+    if args.summary_only:
+        print_summary(target_root)
+        return 0
+
+    if not args.all and not args.source:
+        parser.error("--all or --source is required")
+
+    # Network-touching paths require the third-party deps; fail early with
+    # a single, actionable message instead of partway through a source.
+    _require_runtime_deps()
+
+    sources_to_run = list(SOURCES_META.keys()) if args.all else [args.source]
+
+    for s in sources_to_run:
+        try:
+            new: list[dict]
+            if s == "bioicons":
+                new = download_bioicons(target_root)
+            elif s == "phylopic":
+                new = download_phylopic(target_root, args.max_per_source)
+            elif s == "nih_bioart":
+                if not args.zip:
+                    print("\n[3/6] NIH BioArt requires --zip <path> (site is a SPA, no scrape).")
+                    new = []
+                else:
+                    new = ingest_nih_bioart_zip(target_root, Path(args.zip).expanduser())
+            elif s == "reactome":
+                new = download_reactome(target_root)
+            elif s == "scidraw":
+                new = download_scidraw(target_root, args.max_per_source)
+            elif s == "servier":
+                if not args.pptx:
+                    print("\n[6/6] Servier requires --pptx <path>; skipping.")
+                    new = []
+                else:
+                    new = extract_servier_pptx(target_root, Path(args.pptx).expanduser())
+            else:
+                new = []
+            added, total = merge_index(target_root, new)
+            print(f"  → index.json: +{added} new, total {total}")
+        except KeyboardInterrupt:
+            print("\n[interrupted by user]", file=sys.stderr)
+            break
+        except Exception as exc:
+            print(f"  [{s} failed] {exc}", file=sys.stderr)
+
+    print_summary(target_root)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -44,15 +44,24 @@ from pathlib import Path
 import yaml
 from lxml import etree
 
-# Optional deps — lazy-checked per command.
+# Optional deps — lazy-checked per command and per asset type.
 # Catch both ImportError (package missing) and OSError (e.g. cairosvg installed
 # but libcairo system library missing on the host).
+#
+# The two flags are split intentionally: `cairosvg` is only needed to
+# rasterize SVG; bitmap-only workflows (preview/export of .png/.jpg from a
+# library that's all PhyloPic raster fallbacks etc.) can run on Pillow alone.
+try:
+    from PIL import Image, ImageDraw, ImageFont
+    HAS_PILLOW = True
+except (ImportError, OSError):
+    HAS_PILLOW = False
+
 try:
     import cairosvg
-    from PIL import Image, ImageDraw, ImageFont
-    HAS_PREVIEW = True
+    HAS_CAIROSVG = True
 except (ImportError, OSError):
-    HAS_PREVIEW = False
+    HAS_CAIROSVG = False
 
 try:
     from pptx import Presentation
@@ -556,9 +565,10 @@ def _filter_for_grid(args: argparse.Namespace, records: list[dict]) -> list[dict
 
 def cmd_preview(args: argparse.Namespace) -> int:
     """Render a thumbnail grid of matched elements as a single PNG."""
-    if not HAS_PREVIEW:
-        print("Error: cmd preview requires `cairosvg` and `Pillow`", file=sys.stderr)
-        print("       pip install cairosvg pillow", file=sys.stderr)
+    if not HAS_PILLOW:
+        print("Error: cmd preview requires `Pillow` (always) and `cairosvg` "
+              "(when any asset is SVG)", file=sys.stderr)
+        print("       pip install pillow cairosvg", file=sys.stderr)
         return 1
 
     matches = _filter_for_grid(args, load_unified_index())
@@ -595,6 +605,11 @@ def cmd_preview(args: argparse.Namespace) -> int:
         ext = svg_path.suffix.lower()
         try:
             if ext == ".svg":
+                if not HAS_CAIROSVG:
+                    draw.rectangle([x, y, x + cell, y + cell], outline="#888")
+                    draw.text((x + 4, y + 4), "cairosvg missing",
+                              fill="#888", font=font)
+                    continue
                 png_bytes = cairosvg.svg2png(
                     url=str(svg_path),
                     output_width=cell,
@@ -640,9 +655,9 @@ def cmd_export(args: argparse.Namespace) -> int:
         print("Error: cmd export requires `python-pptx`", file=sys.stderr)
         print("       pip install python-pptx", file=sys.stderr)
         return 1
-    if not HAS_PREVIEW:
-        print("Error: cmd export also needs `cairosvg` + `Pillow`", file=sys.stderr)
-        return 1
+    # Pillow is only needed if we have to peek at bitmaps; cairosvg is only
+    # needed to rasterize SVG. We check per-asset below; the only hard
+    # gate here is python-pptx (no point continuing without it).
 
     records = load_unified_index()
     by_id = {r["id"]: r for r in records}
@@ -682,6 +697,10 @@ def cmd_export(args: argparse.Namespace) -> int:
             # python-pptx accepts .png/.jpg directly; .svg must be rasterized;
             # other formats (.ai/.eps/.emf/.wmf) need an external converter.
             if ext == ".svg":
+                if not HAS_CAIROSVG:
+                    print(f"  [skip] {r['id']}: SVG asset needs cairosvg "
+                          "(pip install cairosvg)", file=sys.stderr)
+                    continue
                 picture_path = tmp_dir / f"{r['id']}.png"
                 try:
                     cairosvg.svg2png(

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -393,26 +393,44 @@ def cmd_check(args: argparse.Namespace) -> int:
         print("Hint: create one with project's element requirements.")
         return 1
 
-    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
     print(f"\n=== Project: {args.project} ===\n")
     have: list[tuple[dict, str, str]] = []
     missing: list[dict] = []
 
+    # Walk the unified index once so v0.1.1 CC0 records show up as "have"
+    # alongside legacy YAML rows. The legacy walk stays as the second tier
+    # to preserve the v0.1.0 contract of matching on `subject`+`style`.
+    unified_records = load_unified_index()
+
     for req in manifest.get("elements_needed", []):
         found = False
-        for category in CATEGORIES:
-            idx_path = LIBRARY_ROOT / category / "_index.yaml"
-            if not idx_path.exists():
-                continue
-            idx = yaml.safe_load(idx_path.read_text()) or {"elements": []}
-            for entry in idx.get("elements", []):
-                if (req["subject"].lower() in entry.get("subject", "").lower()
-                        and entry.get("style") == req.get("style")):
-                    have.append((req, category, entry["file"]))
-                    found = True
-                    break
-            if found:
+        # Tier 1: unified index (CC0 bulk + already-merged legacy rows).
+        for r in unified_records:
+            name = (r.get("name") or "").lower()
+            tags = [(t or "").lower() for t in r.get("tags", [])]
+            if (req["subject"].lower() in name
+                    and (req.get("style") or "") in tags):
+                have.append((req, r.get("category", ""), r.get("file", "")))
+                found = True
                 break
+
+        # Tier 2: per-category legacy YAML (preserves v0.1.0 contract).
+        if not found:
+            for category in CATEGORIES:
+                idx_path = LIBRARY_ROOT / category / "_index.yaml"
+                if not idx_path.exists():
+                    continue
+                idx = yaml.safe_load(idx_path.read_text()) or {"elements": []}
+                for entry in idx.get("elements", []):
+                    if (req["subject"].lower() in entry.get("subject", "").lower()
+                            and entry.get("style") == req.get("style")):
+                        have.append((req, category, entry["file"]))
+                        found = True
+                        break
+                if found:
+                    break
+
         if not found:
             missing.append(req)
 
@@ -596,61 +614,63 @@ def cmd_export(args: argparse.Namespace) -> int:
     prs.slide_height = Inches(7.5)
     blank_layout = prs.slide_layouts[6]
 
-    # Use a tempfile-managed dir for cross-platform safety.
-    tmp_dir = Path(tempfile.mkdtemp(prefix="library_export_"))
-
-    print(f"Exporting {len(selected)} elements to PPTX (tmp: {tmp_dir})...")
-    for r in selected:
-        svg_path = resolve_svg_path(r)
-        if not svg_path.exists():
-            continue
-        ext = svg_path.suffix.lower()
-        # python-pptx accepts .png/.jpg directly; .svg must be rasterized;
-        # other formats (.ai/.eps/.emf/.wmf) need an external converter.
-        if ext == ".svg":
-            picture_path = tmp_dir / f"{r['id']}.png"
-            try:
-                cairosvg.svg2png(
-                    url=str(svg_path),
-                    write_to=str(picture_path),
-                    output_width=1200,
-                )
-            except Exception as exc:
-                print(f"  [skip] {r['id']}: SVG render failed ({type(exc).__name__}: {exc})",
+    # TemporaryDirectory ensures the rasterized PNGs get cleaned up regardless
+    # of which branch we exit through (success / cairosvg failure / ctrl-C).
+    with tempfile.TemporaryDirectory(prefix="library_export_") as tmp_str:
+        tmp_dir = Path(tmp_str)
+        print(f"Exporting {len(selected)} elements to PPTX (tmp: {tmp_dir})...")
+        for r in selected:
+            svg_path = resolve_svg_path(r)
+            if not svg_path.exists():
+                continue
+            ext = svg_path.suffix.lower()
+            # python-pptx accepts .png/.jpg directly; .svg must be rasterized;
+            # other formats (.ai/.eps/.emf/.wmf) need an external converter.
+            if ext == ".svg":
+                picture_path = tmp_dir / f"{r['id']}.png"
+                try:
+                    cairosvg.svg2png(
+                        url=str(svg_path),
+                        write_to=str(picture_path),
+                        output_width=1200,
+                    )
+                except Exception as exc:
+                    print(f"  [skip] {r['id']}: SVG render failed "
+                          f"({type(exc).__name__}: {exc})",
+                          file=sys.stderr)
+                    continue
+            elif ext in (".png", ".jpg", ".jpeg"):
+                picture_path = svg_path
+            else:
+                print(f"  [skip] {r['id']}: unsupported format {ext} "
+                      "(needs libreoffice or inkscape conversion)",
                       file=sys.stderr)
                 continue
-        elif ext in (".png", ".jpg", ".jpeg"):
-            picture_path = svg_path
-        else:
-            print(f"  [skip] {r['id']}: unsupported format {ext} "
-                  "(needs libreoffice or inkscape conversion)",
-                  file=sys.stderr)
-            continue
 
-        slide = prs.slides.add_slide(blank_layout)
-        slide.shapes.add_picture(str(picture_path), Inches(2.5), Inches(1.0),
-                                 height=Inches(4.5))
+            slide = prs.slides.add_slide(blank_layout)
+            slide.shapes.add_picture(str(picture_path), Inches(2.5), Inches(1.0),
+                                     height=Inches(4.5))
 
-        title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.3),
-                                             Inches(12), Inches(0.6))
-        title_box.text_frame.text = r["name"]
-        title_box.text_frame.paragraphs[0].font.size = Pt(24)
-        title_box.text_frame.paragraphs[0].font.bold = True
+            title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.3),
+                                                 Inches(12), Inches(0.6))
+            title_box.text_frame.text = r["name"]
+            title_box.text_frame.paragraphs[0].font.size = Pt(24)
+            title_box.text_frame.paragraphs[0].font.bold = True
 
-        footer = slide.shapes.add_textbox(Inches(0.5), Inches(6.6),
-                                          Inches(12), Inches(0.6))
-        footer.text_frame.text = (
-            f"{r['id']}  |  source: {r['source']}  |  license: {r['license']}"
-        )
-        footer.text_frame.paragraphs[0].font.size = Pt(11)
+            footer = slide.shapes.add_textbox(Inches(0.5), Inches(6.6),
+                                              Inches(12), Inches(0.6))
+            footer.text_frame.text = (
+                f"{r['id']}  |  source: {r['source']}  |  license: {r['license']}"
+            )
+            footer.text_frame.paragraphs[0].font.size = Pt(11)
 
-        if r.get("attribution_required"):
-            attr_p = footer.text_frame.add_paragraph()
-            attr_p.text = f"ATTRIBUTION: {r.get('attribution', '')}"
-            attr_p.font.size = Pt(10)
+            if r.get("attribution_required"):
+                attr_p = footer.text_frame.add_paragraph()
+                attr_p.text = f"ATTRIBUTION: {r.get('attribution', '')}"
+                attr_p.font.size = Pt(10)
 
-    out_path = Path(args.output).expanduser()
-    prs.save(str(out_path))
+        out_path = Path(args.output).expanduser()
+        prs.save(str(out_path))
     print(f"Saved: {out_path}")
     return 0
 
@@ -661,7 +681,11 @@ def cmd_attribution(args: argparse.Namespace) -> int:
 
     if args.ids:
         wanted = set(args.ids.split(","))
-        selected = [r for r in records if r["id"] in wanted]
+        # Even when the caller pipes in IDs explicitly, only emit attribution
+        # for records that need it; otherwise feeding `search --ids-only` (CC0
+        # included) into here would bloat the caption with public-domain rows.
+        selected = [r for r in records
+                    if r["id"] in wanted and r.get("attribution_required")]
     else:
         selected = [r for r in records if r.get("attribution_required")]
 

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -261,9 +261,26 @@ def cmd_register(args: argparse.Namespace) -> int:
     target_dir = LIBRARY_ROOT / category
     target_dir.mkdir(parents=True, exist_ok=True)
 
+    # All three components are filename-only (no `/`, no `..`, no `\`). Slugify
+    # to `[a-z0-9-]` first, then sanity-check that the resulting absolute path
+    # never escapes the target category directory.
     safe_subject = re.sub(r"[^a-z0-9]+", "-", args.subject.lower()).strip("-")
-    target_file = f"{safe_subject}-{args.style}-v{args.version}.svg"
+    safe_style = re.sub(r"[^a-z0-9]+", "-", args.style.lower()).strip("-")
+    safe_version = re.sub(r"[^a-z0-9]+", "-", str(args.version).lower()).strip("-")
+    if not (safe_subject and safe_style and safe_version):
+        print("Error: --subject / --style / --version must contain at least "
+              "one alphanumeric character", file=sys.stderr)
+        return 1
+
+    target_file = f"{safe_subject}-{safe_style}-v{safe_version}.svg"
     target_path = target_dir / target_file
+    target_dir_resolved = target_dir.resolve()
+    if target_path.resolve().parent != target_dir_resolved:
+        # Defensive: slugification should already prevent this, but the check
+        # makes the path-traversal claim auditable rather than implicit.
+        print(f"Error: target path escapes {target_dir_resolved}", file=sys.stderr)
+        return 1
+
     target_path.write_bytes(src.read_bytes())
 
     index_path = target_dir / "_index.yaml"
@@ -630,12 +647,15 @@ def cmd_export(args: argparse.Namespace) -> int:
     records = load_unified_index()
     by_id = {r["id"]: r for r in records}
 
-    if args.ids:
+    if args.ids and not args.query:
         wanted_ids = args.ids.split(",")
         selected = [by_id[i] for i in wanted_ids if i in by_id]
-    elif args.query:
-        q = args.query.lower()
-        selected = [r for r in records if q in r.get("name", "").lower()][: args.max]
+    elif args.query or args.ids:
+        # Reuse the same filter as `preview` so the same query returns the
+        # same set in both commands. `_filter_for_grid` honours args.query
+        # against name+category+tags, narrows by args.ids if provided, and
+        # caps to args.max — matching preview's semantics.
+        selected = _filter_for_grid(args, records)
     else:
         print("Error: --ids or --query required", file=sys.stderr)
         return 1

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -286,6 +286,14 @@ def cmd_register(args: argparse.Namespace) -> int:
         "used_in": [],
         "license": args.license,
     }
+    # Upsert by file: re-running `register` overwrites the on-disk SVG, and
+    # the metadata must reflect the new run. Otherwise `load_unified_index()`
+    # dedupes by derived id and pins the *first* row, so search/export/
+    # attribution would keep showing stale metadata.
+    index["elements"] = [
+        existing for existing in index["elements"]
+        if existing.get("file") != target_file
+    ]
     index["elements"].append(entry)
     index_path.write_text(yaml.safe_dump(index, allow_unicode=True, sort_keys=False))
 
@@ -362,22 +370,42 @@ def cmd_search(args: argparse.Namespace) -> int:
 
 
 def cmd_audit(args: argparse.Namespace) -> int:
-    """Sweep every category directory and list QC failures."""
+    """QC every SVG in the unified index (CC0 bulk + legacy YAML rows).
+
+    Walking the unified index instead of a CATEGORIES dir glob means
+    bootstrapped CC0 assets under e.g. `library/cells/immune/` are no longer
+    silently skipped — those rows are merged into the index by
+    `load_unified_index()`. Non-SVG assets (.png/.ai/.emf) are out of scope
+    for QC (it inspects path/text/gradient counts) and are skipped here.
+    """
     failed: list[tuple[Path, dict]] = []
     total = 0
-    for category in CATEGORIES:
-        cat_dir = LIBRARY_ROOT / category
-        if not cat_dir.exists():
+    seen: set[Path] = set()
+    for record in load_unified_index():
+        svg = resolve_svg_path(record)
+        if svg.suffix.lower() != ".svg":
             continue
-        for svg in cat_dir.glob("*.svg"):
-            total += 1
-            qc = quality_check(svg)
-            if not qc["pass"]:
-                failed.append((svg, qc))
+        try:
+            resolved = svg.resolve()
+        except OSError:
+            continue
+        if resolved in seen or not svg.exists():
+            continue
+        seen.add(resolved)
+        total += 1
+        qc = quality_check(svg)
+        if not qc["pass"]:
+            failed.append((svg, qc))
 
     print(f"\nAudit complete: {total} elements scanned, {len(failed)} failed QC.\n")
     for svg, qc in failed:
-        print(f"  FAIL: {svg.relative_to(LIBRARY_ROOT)}")
+        # `try/except` guards against unified-index paths outside LIBRARY_ROOT
+        # (would happen if a record's `_root` points elsewhere).
+        try:
+            label = svg.relative_to(LIBRARY_ROOT)
+        except ValueError:
+            label = svg
+        print(f"  FAIL: {label}")
         for check_name, (passed, detail) in qc["checks"].items():
             if not passed:
                 print(f"    - {check_name}: {detail}")
@@ -406,11 +434,18 @@ def cmd_check(args: argparse.Namespace) -> int:
     for req in manifest.get("elements_needed", []):
         found = False
         # Tier 1: unified index (CC0 bulk + already-merged legacy rows).
+        # CC0 record `tags` carry content categories (e.g. ["immune"],
+        # ["silhouette"]), not visual style names like "flat-blue", so the
+        # style guard MUST treat an unspecified style as a wildcard rather
+        # than as the empty string "in" tags. Also, when a style IS
+        # specified, an empty `tags` list still shouldn't auto-fail — fall
+        # through to the legacy YAML tier below.
+        req_style = (req.get("style") or "").lower()
         for r in unified_records:
             name = (r.get("name") or "").lower()
             tags = [(t or "").lower() for t in r.get("tags", [])]
-            if (req["subject"].lower() in name
-                    and (req.get("style") or "") in tags):
+            style_ok = (not req_style) or (req_style in tags)
+            if req["subject"].lower() in name and style_ok:
                 have.append((req, r.get("category", ""), r.get("file", "")))
                 found = True
                 break

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+"""
+library_tools.py — manage the local scientific element library.
+
+Commands:
+  qc          — quality-check a single SVG element (no registration side effect)
+  register    — register a QC-passed element into a per-category _index.yaml
+  search      — full-text search across the unified index (CC0 bulk + legacy YAML)
+  audit       — sweep every category and list every element that fails QC
+  check       — given a project manifest, list which required elements are
+                already in the library and which are missing
+  stats       — summary of the unified index by source / category / license
+  preview     — render a thumbnail grid PNG of the matched elements
+  export      — bundle matched elements into a one-element-per-slide PPTX
+  attribution — emit a markdown attribution block for CC-BY elements
+                (use before submitting a figure)
+
+Dependencies:
+  - lxml, pyyaml         (always)
+  - cairosvg, pillow     (preview, export)
+  - python-pptx          (export)
+
+Usage:
+  python library_tools.py qc cells/treg-flat-v1.svg
+  python library_tools.py register cells/treg-flat-v1.svg \
+         --subject "regulatory T cell" --style flat-blue --provider recraft-v3
+  python library_tools.py search "T cell" --license CC0
+  python library_tools.py stats
+  python library_tools.py preview --query "neuron" --output preview.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from collections import Counter
+from datetime import date
+from io import BytesIO
+from pathlib import Path
+
+import yaml
+from lxml import etree
+
+# Optional deps — lazy-checked per command.
+# Catch both ImportError (package missing) and OSError (e.g. cairosvg installed
+# but libcairo system library missing on the host).
+try:
+    import cairosvg
+    from PIL import Image, ImageDraw, ImageFont
+    HAS_PREVIEW = True
+except (ImportError, OSError):
+    HAS_PREVIEW = False
+
+try:
+    from pptx import Presentation
+    from pptx.util import Inches, Pt
+    HAS_PPTX = True
+except (ImportError, OSError):
+    HAS_PPTX = False
+
+
+SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+LIBRARY_ROOT = Path.home() / "sci-illustration-library"
+CATEGORIES = [
+    "cells", "molecules", "organelles", "tissues",
+    "organs", "equipment", "pathways", "arrows",
+]
+
+
+# ---------------------------------------------------------------------------
+# Unified index loader (CC0 bulk JSON + legacy per-category YAML)
+# ---------------------------------------------------------------------------
+
+
+def load_unified_index() -> list[dict]:
+    """Merge the CC0 bulk index.json with each category's legacy _index.yaml.
+
+    Returns a list of records sharing one schema; legacy records carry
+    `_legacy: True` and a `_meta` field with the original YAML row.
+    """
+    records: list[dict] = []
+    seen_ids: set[str] = set()
+
+    # 1. CC0 bulk index produced by download_cc0_seed.py.
+    json_index = LIBRARY_ROOT / "library" / "index.json"
+    if json_index.exists():
+        try:
+            data = json.loads(json_index.read_text())
+            for r in data:
+                rid = r.get("id")
+                if rid and rid not in seen_ids:
+                    seen_ids.add(rid)
+                    r.setdefault("_root", json_index.parent)
+                    records.append(r)
+        except Exception as exc:
+            print(f"[warn] failed to parse {json_index}: {exc}", file=sys.stderr)
+
+    # 2. Legacy per-category YAML (manually registered elements).
+    for category in CATEGORIES:
+        yaml_index = LIBRARY_ROOT / category / "_index.yaml"
+        if not yaml_index.exists():
+            continue
+        try:
+            idx = yaml.safe_load(yaml_index.read_text()) or {"elements": []}
+            for entry in idx.get("elements", []):
+                fid = f"manual-{category}-{entry.get('file', '').replace('.svg', '')}"
+                if fid in seen_ids:
+                    continue
+                seen_ids.add(fid)
+                records.append({
+                    "id": fid,
+                    "name": entry.get("subject", ""),
+                    "tags": [entry.get("style", "")],
+                    "category": category,
+                    "source": entry.get("provider", "manual"),
+                    "license": entry.get("license", "research-use-only"),
+                    "license_url": "",
+                    "attribution_required": False,
+                    "file": str(Path(category) / entry.get("file", "")),
+                    "_root": LIBRARY_ROOT,
+                    "_legacy": True,
+                    "_meta": entry,
+                })
+        except Exception as exc:
+            print(f"[warn] failed to parse {yaml_index}: {exc}", file=sys.stderr)
+
+    return records
+
+
+def resolve_svg_path(record: dict) -> Path:
+    """Convert a unified-index record into an absolute SVG path."""
+    root = record.get("_root", LIBRARY_ROOT / "library")
+    return Path(root) / record["file"]
+
+
+# ---------------------------------------------------------------------------
+# Quality check
+# ---------------------------------------------------------------------------
+
+
+def quality_check(svg_path: Path) -> dict:
+    """Inspect one SVG for path count, color palette, embedded text, etc."""
+    try:
+        tree = etree.parse(str(svg_path))
+        root = tree.getroot()
+    except Exception as exc:
+        return {"pass": False, "error": str(exc)}
+
+    paths = root.findall(".//svg:path", SVG_NS)
+    texts = root.findall(".//svg:text", SVG_NS)
+    images = root.findall(".//svg:image", SVG_NS)
+    gradients = (root.findall(".//svg:linearGradient", SVG_NS)
+                 + root.findall(".//svg:radialGradient", SVG_NS))
+
+    total_nodes = sum(
+        len(re.findall(r"[MLCQAHVZmlcqahvz]", p.get("d", "")))
+        for p in paths
+    )
+
+    fills: set[str] = set()
+    for elem in root.iter():
+        fill = elem.get("fill") or ""
+        if (fill and fill not in ("none", "transparent")
+                and not fill.startswith("url")):
+            fills.add(fill.lower())
+
+    checks = {
+        "path_count":       (len(paths) < 200, f"{len(paths)} paths"),
+        "no_text_nodes":    (len(texts) == 0, f"{len(texts)} <text> nodes"),
+        "no_image_nodes":   (len(images) == 0, f"{len(images)} <image> nodes"),
+        "node_count":       (total_nodes < 2000, f"{total_nodes} path commands"),
+        "color_palette":    (len(fills) <= 8, f"{len(fills)} unique colors"),
+        "gradient_minimal": (len(gradients) <= 2, f"{len(gradients)} gradients"),
+    }
+
+    return {
+        "pass": all(passed for passed, _ in checks.values()),
+        "checks": checks,
+        "stats": {
+            "paths": len(paths),
+            "nodes": total_nodes,
+            "colors": len(fills),
+            "gradients": len(gradients),
+            "texts": len(texts),
+            "images": len(images),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_qc(args: argparse.Namespace) -> int:
+    """Print a QC report for one SVG."""
+    path = Path(args.file)
+    if not path.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        return 1
+
+    result = quality_check(path)
+    print(f"\n=== QC Report: {path.name} ===\n")
+
+    if "error" in result:
+        print(f"FATAL: {result['error']}")
+        return 1
+
+    for check_name, (passed, detail) in result["checks"].items():
+        symbol = "PASS" if passed else "FAIL"
+        print(f"  [{symbol}] {check_name:20s}: {detail}")
+
+    verdict = "ACCEPT (ready to register)" if result["pass"] else "REJECT (regenerate or simplify)"
+    print(f"\nVerdict: {verdict}\n")
+    return 0 if result["pass"] else 1
+
+
+def get_category_for_subject(subject: str) -> str:
+    """Best-effort mapping from a subject string to a top-level category."""
+    subject_lower = subject.lower()
+    rules = {
+        "cells": ["cell", "cyte", "phage", "blast"],
+        "molecules": ["protein", "antibody", "dna", "rna", "enzyme",
+                      "receptor", "ligand"],
+        "organelles": ["mitochond", "nucleus", "golgi", "endoplasmic",
+                       "lysosome", "ribosome"],
+        "tissues": ["tissue", "epithelium", "stroma", "matrix",
+                    "glomerul", "lobule"],
+        "organs": ["liver", "kidney", "lung", "brain", "heart",
+                   "pancreas", "spleen"],
+        "equipment": ["microscope", "cytometer", "pcr", "plate",
+                      "tube", "chamber", "array"],
+        "pathways": ["pathway", "cascade", "signaling", "phospho",
+                     "transport"],
+    }
+    for category, keywords in rules.items():
+        if any(kw in subject_lower for kw in keywords):
+            return category
+    return "molecules"  # fallback
+
+
+def cmd_register(args: argparse.Namespace) -> int:
+    """Register a QC-passed SVG into the matching category's _index.yaml."""
+    src = Path(args.file)
+    if not src.exists():
+        print(f"Error: file not found: {src}", file=sys.stderr)
+        return 1
+
+    qc = quality_check(src)
+    if not qc["pass"]:
+        print("QC FAILED. Cannot register. Run `qc` for details.", file=sys.stderr)
+        return 1
+
+    category = args.category or get_category_for_subject(args.subject)
+    target_dir = LIBRARY_ROOT / category
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_subject = re.sub(r"[^a-z0-9]+", "-", args.subject.lower()).strip("-")
+    target_file = f"{safe_subject}-{args.style}-v{args.version}.svg"
+    target_path = target_dir / target_file
+    target_path.write_bytes(src.read_bytes())
+
+    index_path = target_dir / "_index.yaml"
+    if index_path.exists():
+        index = yaml.safe_load(index_path.read_text()) or {"elements": []}
+    else:
+        index = {"elements": []}
+
+    entry = {
+        "file": target_file,
+        "subject": args.subject,
+        "style": args.style,
+        "style_ref": args.style_ref or "",
+        "provider": args.provider,
+        "style_id": args.style_id or "",
+        "generated_at": str(date.today()),
+        "nodes": qc["stats"]["nodes"],
+        "colors": qc["stats"]["colors"],
+        "qc_passed": True,
+        "used_in": [],
+        "license": args.license,
+    }
+    index["elements"].append(entry)
+    index_path.write_text(yaml.safe_dump(index, allow_unicode=True, sort_keys=False))
+
+    print(f"Registered: {target_path}")
+    print(f"Updated index: {index_path}")
+    return 0
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    """Full-text search the unified index."""
+    records = load_unified_index()
+    if not records:
+        print("Library is empty. Run download_cc0_seed.py to seed.")
+        return 0
+
+    query = (args.query or "").lower().strip()
+    matches: list[dict] = []
+    for r in records:
+        haystack = " ".join([
+            r.get("name", ""),
+            r.get("category", ""),
+            r.get("id", ""),
+            " ".join(r.get("tags", [])),
+        ]).lower()
+
+        if query and query not in haystack:
+            continue
+        if args.category and r.get("category") != args.category:
+            continue
+        if args.source and args.source not in r.get("source", ""):
+            continue
+        if args.license and args.license.upper() not in r.get("license", "").upper():
+            continue
+        # Backward-compat flags from v0.1.0.
+        if args.subject and args.subject.lower() not in r.get("name", "").lower():
+            continue
+        if args.style and not any(args.style in t for t in r.get("tags", [])):
+            continue
+        if args.provider and args.provider not in r.get("source", ""):
+            continue
+
+        matches.append(r)
+
+    if args.max:
+        matches = matches[: args.max]
+
+    if not matches:
+        print("No matches.")
+        return 0
+
+    print(f"\nFound {len(matches)} element(s):\n")
+    for r in matches:
+        attr_flag = " [ATTR]" if r.get("attribution_required") else ""
+        print(f"  {r['id']}{attr_flag}")
+        print(f"    name:     {r['name']}")
+        print(f"    category: {r['category']}")
+        print(f"    source:   {r['source']}  ({r['license']})")
+        print(f"    file:     {r['file']}")
+        print()
+
+    if args.ids_only:
+        print(",".join(r["id"] for r in matches))
+
+    return 0
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    """Sweep every category directory and list QC failures."""
+    failed: list[tuple[Path, dict]] = []
+    total = 0
+    for category in CATEGORIES:
+        cat_dir = LIBRARY_ROOT / category
+        if not cat_dir.exists():
+            continue
+        for svg in cat_dir.glob("*.svg"):
+            total += 1
+            qc = quality_check(svg)
+            if not qc["pass"]:
+                failed.append((svg, qc))
+
+    print(f"\nAudit complete: {total} elements scanned, {len(failed)} failed QC.\n")
+    for svg, qc in failed:
+        print(f"  FAIL: {svg.relative_to(LIBRARY_ROOT)}")
+        for check_name, (passed, detail) in qc["checks"].items():
+            if not passed:
+                print(f"    - {check_name}: {detail}")
+        print()
+    return 0 if not failed else 1
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    """Compare a project manifest's element list against what's registered."""
+    manifest_path = LIBRARY_ROOT / "_final" / args.project / "manifest.yaml"
+    if not manifest_path.exists():
+        print(f"Error: manifest not found: {manifest_path}", file=sys.stderr)
+        print("Hint: create one with project's element requirements.")
+        return 1
+
+    manifest = yaml.safe_load(manifest_path.read_text())
+    print(f"\n=== Project: {args.project} ===\n")
+    have: list[tuple[dict, str, str]] = []
+    missing: list[dict] = []
+
+    for req in manifest.get("elements_needed", []):
+        found = False
+        for category in CATEGORIES:
+            idx_path = LIBRARY_ROOT / category / "_index.yaml"
+            if not idx_path.exists():
+                continue
+            idx = yaml.safe_load(idx_path.read_text()) or {"elements": []}
+            for entry in idx.get("elements", []):
+                if (req["subject"].lower() in entry.get("subject", "").lower()
+                        and entry.get("style") == req.get("style")):
+                    have.append((req, category, entry["file"]))
+                    found = True
+                    break
+            if found:
+                break
+        if not found:
+            missing.append(req)
+
+    print(f"In library ({len(have)}):")
+    for req, category, file in have:
+        print(f"  [OK] {req['subject']:30s} -> {category}/{file}")
+
+    print(f"\nMissing ({len(missing)}):")
+    for req in missing:
+        print(f"  [..] {req['subject']:30s} (style: {req.get('style')})")
+
+    if missing:
+        print(f"\nNext step: generate {len(missing)} missing elements via "
+              "recraft-scientific-illustration skill.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# New commands: stats / preview / export / attribution
+# ---------------------------------------------------------------------------
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    """Print a one-shot summary of the unified library."""
+    records = load_unified_index()
+    if not records:
+        print("Library is empty.")
+        return 0
+
+    by_source = Counter(r.get("source", "?") for r in records)
+    by_category = Counter(r.get("category", "?") for r in records)
+    by_license = Counter(r.get("license", "?") for r in records)
+
+    print(f"\n{'=' * 60}")
+    print(f"Library Stats  (root: {LIBRARY_ROOT})")
+    print(f"{'=' * 60}")
+    print(f"\nTotal elements: {len(records)}\n")
+
+    print("By source:")
+    for s, n in by_source.most_common():
+        print(f"  {s:25s} {n:>6d}")
+
+    print("\nBy category:")
+    for c, n in by_category.most_common():
+        print(f"  {c:25s} {n:>6d}")
+
+    print("\nBy license:")
+    for lic, n in by_license.most_common():
+        print(f"  {lic:25s} {n:>6d}")
+
+    attr_required = sum(1 for r in records if r.get("attribution_required"))
+    print(f"\nAttribution required: {attr_required} elements")
+    return 0
+
+
+def _filter_for_grid(args: argparse.Namespace, records: list[dict]) -> list[dict]:
+    """Shared selector for preview / export."""
+    query = (args.query or "").lower()
+    matches = [
+        r for r in records
+        if not query
+        or query in r.get("name", "").lower()
+        or query in r.get("category", "").lower()
+        or query in " ".join(r.get("tags", [])).lower()
+    ]
+    if args.ids:
+        wanted = set(args.ids.split(","))
+        matches = [r for r in matches if r["id"] in wanted]
+    return matches[: args.max]
+
+
+def cmd_preview(args: argparse.Namespace) -> int:
+    """Render a thumbnail grid of matched elements as a single PNG."""
+    if not HAS_PREVIEW:
+        print("Error: cmd preview requires `cairosvg` and `Pillow`", file=sys.stderr)
+        print("       pip install cairosvg pillow", file=sys.stderr)
+        return 1
+
+    matches = _filter_for_grid(args, load_unified_index())
+    if not matches:
+        print("No matches to preview.")
+        return 0
+
+    cell = args.cell_size
+    cols = args.cols
+    rows = (len(matches) + cols - 1) // cols
+    label_h = 28
+    grid_w = cols * (cell + 8) + 8
+    grid_h = rows * (cell + label_h + 12) + 8
+
+    canvas = Image.new("RGB", (grid_w, grid_h), "white")
+    draw = ImageDraw.Draw(canvas)
+    try:
+        font = ImageFont.truetype("DejaVuSans.ttf", 10)
+    except OSError:
+        font = ImageFont.load_default()
+
+    print(f"Rendering {len(matches)} thumbnails ({cols}x{rows})...")
+    for i, r in enumerate(matches):
+        row, col = i // cols, i % cols
+        x = 8 + col * (cell + 8)
+        y = 8 + row * (cell + label_h + 12)
+
+        svg_path = resolve_svg_path(r)
+        if not svg_path.exists():
+            draw.rectangle([x, y, x + cell, y + cell], outline="red")
+            draw.text((x + 4, y + cell // 2), "missing", fill="red", font=font)
+            continue
+
+        try:
+            png_bytes = cairosvg.svg2png(
+                url=str(svg_path),
+                output_width=cell,
+                output_height=cell,
+            )
+            img = Image.open(BytesIO(png_bytes)).convert("RGB")
+            canvas.paste(img, (x, y))
+        except Exception:
+            draw.rectangle([x, y, x + cell, y + cell], outline="orange")
+            draw.text((x + 4, y + 4), "render fail", fill="orange", font=font)
+
+        name = r.get("name", "")[:30]
+        draw.text((x, y + cell + 2), name, fill="black", font=font)
+        draw.text(
+            (x, y + cell + 14),
+            f"{r['source']} | {r['license'][:10]}",
+            fill="#666", font=font,
+        )
+
+    out = Path(args.output).expanduser()
+    canvas.save(out)
+    print(f"Saved preview: {out}")
+    return 0
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    """Bundle matched elements into a one-element-per-slide PPTX."""
+    if not HAS_PPTX:
+        print("Error: cmd export requires `python-pptx`", file=sys.stderr)
+        print("       pip install python-pptx", file=sys.stderr)
+        return 1
+    if not HAS_PREVIEW:
+        print("Error: cmd export also needs `cairosvg` + `Pillow`", file=sys.stderr)
+        return 1
+
+    records = load_unified_index()
+    by_id = {r["id"]: r for r in records}
+
+    if args.ids:
+        wanted_ids = args.ids.split(",")
+        selected = [by_id[i] for i in wanted_ids if i in by_id]
+    elif args.query:
+        q = args.query.lower()
+        selected = [r for r in records if q in r.get("name", "").lower()][: args.max]
+    else:
+        print("Error: --ids or --query required", file=sys.stderr)
+        return 1
+
+    if not selected:
+        print("No elements to export.")
+        return 0
+
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)  # 16:9
+    prs.slide_height = Inches(7.5)
+    blank_layout = prs.slide_layouts[6]
+
+    # Use a tempfile-managed dir for cross-platform safety.
+    tmp_dir = Path(tempfile.mkdtemp(prefix="library_export_"))
+
+    print(f"Exporting {len(selected)} elements to PPTX (tmp: {tmp_dir})...")
+    for r in selected:
+        svg_path = resolve_svg_path(r)
+        if not svg_path.exists():
+            continue
+        png_tmp = tmp_dir / f"{r['id']}.png"
+        try:
+            cairosvg.svg2png(
+                url=str(svg_path),
+                write_to=str(png_tmp),
+                output_width=1200,
+            )
+        except Exception as exc:
+            print(f"  [skip] {r['id']}: render failed ({exc})")
+            continue
+
+        slide = prs.slides.add_slide(blank_layout)
+        slide.shapes.add_picture(str(png_tmp), Inches(2.5), Inches(1.0),
+                                 height=Inches(4.5))
+
+        title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.3),
+                                             Inches(12), Inches(0.6))
+        title_box.text_frame.text = r["name"]
+        title_box.text_frame.paragraphs[0].font.size = Pt(24)
+        title_box.text_frame.paragraphs[0].font.bold = True
+
+        footer = slide.shapes.add_textbox(Inches(0.5), Inches(6.6),
+                                          Inches(12), Inches(0.6))
+        footer.text_frame.text = (
+            f"{r['id']}  |  source: {r['source']}  |  license: {r['license']}"
+        )
+        footer.text_frame.paragraphs[0].font.size = Pt(11)
+
+        if r.get("attribution_required"):
+            attr_p = footer.text_frame.add_paragraph()
+            attr_p.text = f"ATTRIBUTION: {r.get('attribution', '')}"
+            attr_p.font.size = Pt(10)
+
+    out_path = Path(args.output).expanduser()
+    prs.save(str(out_path))
+    print(f"Saved: {out_path}")
+    return 0
+
+
+def cmd_attribution(args: argparse.Namespace) -> int:
+    """Render a markdown attribution block for CC-BY elements."""
+    records = load_unified_index()
+
+    if args.ids:
+        wanted = set(args.ids.split(","))
+        selected = [r for r in records if r["id"] in wanted]
+    else:
+        selected = [r for r in records if r.get("attribution_required")]
+
+    if not selected:
+        print("No attribution-required elements selected.")
+        return 0
+
+    grouped: dict[tuple[str, str], list[dict]] = {}
+    for r in selected:
+        key = (r.get("source", ""), r.get("license", ""))
+        grouped.setdefault(key, []).append(r)
+
+    lines = ["# Figure Asset Attributions\n"]
+    lines.append(f"_Generated {date.today()}_\n")
+    lines.append(f"This figure uses {len(selected)} non-CC0 assets requiring attribution.\n")
+
+    for (source, lic), items in sorted(grouped.items()):
+        lines.append(f"\n## {source} ({lic})\n")
+        seen_attr: set[str] = set()
+        for r in items:
+            attr = r.get("attribution", "") or f"{r.get('source_name', '')} ({lic})"
+            if attr in seen_attr:
+                continue
+            seen_attr.add(attr)
+            lines.append(f"- {attr}")
+        lines.append("")
+
+    lines.append("\n---")
+    lines.append("\n## Suggested figure caption text:\n")
+    cited = sorted({(r.get("attribution") or r.get("source_name", "")) for r in selected})
+    lines.append("> Schematic illustrations adapted from " + ", ".join(cited) + ".")
+
+    output = "\n".join(lines)
+    if args.output:
+        Path(args.output).expanduser().write_text(output)
+        print(f"Saved: {args.output}")
+    else:
+        print(output)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Local scientific element library management",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_qc = sub.add_parser("qc", help="QC a single SVG element")
+    p_qc.add_argument("file", help="path to SVG")
+
+    p_reg = sub.add_parser("register", help="register a QC-passed element")
+    p_reg.add_argument("file", help="path to SVG")
+    p_reg.add_argument("--subject", required=True,
+                       help='element subject, e.g. "regulatory T cell"')
+    p_reg.add_argument("--style", required=True,
+                       help='style label, e.g. "flat-blue"')
+    p_reg.add_argument("--provider", required=True,
+                       choices=["recraft-v3", "gemini-imagen-4",
+                                "zhipu-cogview-4", "minimax", "gpt-image",
+                                "hand-drawn"])
+    p_reg.add_argument("--version", default="1", help="version tag (default: 1)")
+    p_reg.add_argument("--style-ref", help="style reference filename")
+    p_reg.add_argument("--style-id", help="provider-specific style id")
+    p_reg.add_argument("--category", choices=CATEGORIES,
+                       help="category override (default: derived from subject)")
+    p_reg.add_argument("--license", default="research-use-only")
+
+    p_search = sub.add_parser("search", help="search the unified library index")
+    p_search.add_argument("query", nargs="?", default=None,
+                          help="full-text query (matches name/category/tags/id)")
+    p_search.add_argument("--category", choices=CATEGORIES, help="restrict to category")
+    p_search.add_argument("--source", help="restrict to source (bioicons/phylopic/...)")
+    p_search.add_argument("--license", help="license keyword (CC0 / CC-BY / Public)")
+    p_search.add_argument("--max", type=int, default=50, help="cap result count")
+    p_search.add_argument("--ids-only", action="store_true",
+                          help="print a comma-separated list of matched IDs (for piping)")
+    # legacy filters from v0.1.0
+    p_search.add_argument("--subject", help="[legacy] subject keyword")
+    p_search.add_argument("--style", help="[legacy] style keyword")
+    p_search.add_argument("--provider", help="[legacy] provider keyword")
+
+    sub.add_parser("audit", help="QC every element in the library")
+
+    p_check = sub.add_parser("check", help="compare a project manifest against the library")
+    p_check.add_argument("--project", required=True, help="project directory under _final/")
+
+    sub.add_parser("stats", help="summary of the unified index")
+
+    p_prev = sub.add_parser("preview", help="thumbnail grid PNG of matched elements")
+    p_prev.add_argument("--query", help="full-text query")
+    p_prev.add_argument("--ids", help="comma-separated IDs")
+    p_prev.add_argument("--max", type=int, default=64, help="max elements (default 64 = 8x8)")
+    p_prev.add_argument("--cols", type=int, default=8)
+    p_prev.add_argument("--cell-size", type=int, default=120, help="thumbnail edge px")
+    p_prev.add_argument("--output", "-o", default="./preview.png")
+
+    p_export = sub.add_parser("export", help="bundle elements into a PPTX")
+    p_export.add_argument("--ids", help="comma-separated IDs")
+    p_export.add_argument("--query", help="full-text query")
+    p_export.add_argument("--max", type=int, default=20)
+    p_export.add_argument("--output", "-o", default="./elements.pptx")
+
+    p_attr = sub.add_parser("attribution",
+                            help="emit markdown attribution block for CC-BY elements")
+    p_attr.add_argument("--ids", help="comma-separated IDs (default: all attribution-required)")
+    p_attr.add_argument("--output", "-o", help="output markdown path (default stdout)")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    LIBRARY_ROOT.mkdir(parents=True, exist_ok=True)
+
+    handlers = {
+        "qc": cmd_qc,
+        "register": cmd_register,
+        "search": cmd_search,
+        "audit": cmd_audit,
+        "check": cmd_check,
+        "stats": cmd_stats,
+        "preview": cmd_preview,
+        "export": cmd_export,
+        "attribution": cmd_attribution,
+    }
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -63,7 +63,10 @@ except (ImportError, OSError):
 
 
 SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+# Mutated in main() when --library-root is supplied.
 LIBRARY_ROOT = Path.home() / "sci-illustration-library"
+# Top-level legacy categories. The unified index also uses sub-categories
+# like "cells/immune" and "equipment/lab"; CLI filters accept either form.
 CATEGORIES = [
     "cells", "molecules", "organelles", "tissues",
     "organs", "equipment", "pathways", "arrows",
@@ -295,7 +298,9 @@ def cmd_search(args: argparse.Namespace) -> int:
     """Full-text search the unified index."""
     records = load_unified_index()
     if not records:
-        print("Library is empty. Run download_cc0_seed.py to seed.")
+        # Empty CSV (just a newline) when piping; human prompt otherwise.
+        if not args.ids_only:
+            print("Library is empty. Run download_cc0_seed.py to seed.")
         return 0
 
     query = (args.query or "").lower().strip()
@@ -310,8 +315,12 @@ def cmd_search(args: argparse.Namespace) -> int:
 
         if query and query not in haystack:
             continue
-        if args.category and r.get("category") != args.category:
-            continue
+        if args.category:
+            cat = r.get("category", "")
+            # `--category cells` matches "cells" plus any "cells/<sub>".
+            # `--category cells/immune` matches that record exactly.
+            if not (cat == args.category or cat.startswith(args.category + "/")):
+                continue
         if args.source and args.source not in r.get("source", ""):
             continue
         if args.license and args.license.upper() not in r.get("license", "").upper():
@@ -330,7 +339,13 @@ def cmd_search(args: argparse.Namespace) -> int:
         matches = matches[: args.max]
 
     if not matches:
-        print("No matches.")
+        if not args.ids_only:
+            print("No matches.")
+        return 0
+
+    if args.ids_only:
+        # Pure CSV on stdout, nothing else — pipe-safe (e.g. `--ids "$(... --ids-only)"`).
+        print(",".join(r["id"] for r in matches))
         return 0
 
     print(f"\nFound {len(matches)} element(s):\n")
@@ -342,9 +357,6 @@ def cmd_search(args: argparse.Namespace) -> int:
         print(f"    source:   {r['source']}  ({r['license']})")
         print(f"    file:     {r['file']}")
         print()
-
-    if args.ids_only:
-        print(",".join(r["id"] for r in matches))
 
     return 0
 
@@ -510,17 +522,33 @@ def cmd_preview(args: argparse.Namespace) -> int:
             draw.text((x + 4, y + cell // 2), "missing", fill="red", font=font)
             continue
 
+        ext = svg_path.suffix.lower()
         try:
-            png_bytes = cairosvg.svg2png(
-                url=str(svg_path),
-                output_width=cell,
-                output_height=cell,
-            )
-            img = Image.open(BytesIO(png_bytes)).convert("RGB")
-            canvas.paste(img, (x, y))
-        except Exception:
+            if ext == ".svg":
+                png_bytes = cairosvg.svg2png(
+                    url=str(svg_path),
+                    output_width=cell,
+                    output_height=cell,
+                )
+                img = Image.open(BytesIO(png_bytes)).convert("RGB")
+            elif ext in (".png", ".jpg", ".jpeg"):
+                img = Image.open(svg_path).convert("RGB")
+                img.thumbnail((cell, cell))
+            else:
+                # AI / EPS / EMF / WMF — these need an external converter
+                # (libreoffice, inkscape) and aren't worth a hard dep here.
+                draw.rectangle([x, y, x + cell, y + cell], outline="#888")
+                draw.text((x + 4, y + 4), f"unsupported {ext}", fill="#888", font=font)
+                continue
+            # Center-paste raster preview within the cell.
+            paste_x = x + (cell - img.width) // 2
+            paste_y = y + (cell - img.height) // 2
+            canvas.paste(img, (paste_x, paste_y))
+        except Exception as exc:
             draw.rectangle([x, y, x + cell, y + cell], outline="orange")
-            draw.text((x + 4, y + 4), "render fail", fill="orange", font=font)
+            draw.text((x + 4, y + 4),
+                      f"render fail: {type(exc).__name__}",
+                      fill="orange", font=font)
 
         name = r.get("name", "")[:30]
         draw.text((x, y + cell + 2), name, fill="black", font=font)
@@ -576,19 +604,31 @@ def cmd_export(args: argparse.Namespace) -> int:
         svg_path = resolve_svg_path(r)
         if not svg_path.exists():
             continue
-        png_tmp = tmp_dir / f"{r['id']}.png"
-        try:
-            cairosvg.svg2png(
-                url=str(svg_path),
-                write_to=str(png_tmp),
-                output_width=1200,
-            )
-        except Exception as exc:
-            print(f"  [skip] {r['id']}: render failed ({exc})")
+        ext = svg_path.suffix.lower()
+        # python-pptx accepts .png/.jpg directly; .svg must be rasterized;
+        # other formats (.ai/.eps/.emf/.wmf) need an external converter.
+        if ext == ".svg":
+            picture_path = tmp_dir / f"{r['id']}.png"
+            try:
+                cairosvg.svg2png(
+                    url=str(svg_path),
+                    write_to=str(picture_path),
+                    output_width=1200,
+                )
+            except Exception as exc:
+                print(f"  [skip] {r['id']}: SVG render failed ({type(exc).__name__}: {exc})",
+                      file=sys.stderr)
+                continue
+        elif ext in (".png", ".jpg", ".jpeg"):
+            picture_path = svg_path
+        else:
+            print(f"  [skip] {r['id']}: unsupported format {ext} "
+                  "(needs libreoffice or inkscape conversion)",
+                  file=sys.stderr)
             continue
 
         slide = prs.slides.add_slide(blank_layout)
-        slide.shapes.add_picture(str(png_tmp), Inches(2.5), Inches(1.0),
+        slide.shapes.add_picture(str(picture_path), Inches(2.5), Inches(1.0),
                                  height=Inches(4.5))
 
         title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.3),
@@ -673,6 +713,11 @@ def build_parser() -> argparse.ArgumentParser:
         description="Local scientific element library management",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--library-root",
+                        default=str(Path.home() / "sci-illustration-library"),
+                        help=("override library root (default: "
+                              "~/sci-illustration-library; matches the "
+                              "--target flag of download_cc0_seed.py)"))
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_qc = sub.add_parser("qc", help="QC a single SVG element")
@@ -698,7 +743,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_search = sub.add_parser("search", help="search the unified library index")
     p_search.add_argument("query", nargs="?", default=None,
                           help="full-text query (matches name/category/tags/id)")
-    p_search.add_argument("--category", choices=CATEGORIES, help="restrict to category")
+    # Accept any category string — the unified index uses subcategories like
+    # "cells/immune" and "equipment/lab" alongside the top-level CATEGORIES.
+    p_search.add_argument("--category",
+                          help=("restrict to category (top-level e.g. cells, "
+                                "or subcategory e.g. cells/immune)"))
     p_search.add_argument("--source", help="restrict to source (bioicons/phylopic/...)")
     p_search.add_argument("--license", help="license keyword (CC0 / CC-BY / Public)")
     p_search.add_argument("--max", type=int, default=50, help="cap result count")
@@ -741,6 +790,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+
+    # Apply --library-root before any command runs. Mutating the module global
+    # keeps the loader / resolver functions free of an extra plumbing arg.
+    global LIBRARY_ROOT
+    LIBRARY_ROOT = Path(args.library_root).expanduser().resolve()
     LIBRARY_ROOT.mkdir(parents=True, exist_ok=True)
 
     handlers = {

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -827,10 +827,37 @@ def build_parser() -> argparse.ArgumentParser:
                        help='element subject, e.g. "regulatory T cell"')
     p_reg.add_argument("--style", required=True,
                        help='style label, e.g. "flat-blue"')
-    p_reg.add_argument("--provider", required=True,
-                       choices=["recraft-v3", "gemini-imagen-4",
-                                "zhipu-cogview-4", "minimax", "gpt-image",
-                                "hand-drawn"])
+    p_reg.add_argument(
+        "--provider", required=True,
+        choices=[
+            # legacy v0.1.0 alias (kept for backward compat with existing
+            # _index.yaml rows registered before the v0.1.1 tier rename).
+            "recraft-v3",
+            # v0.1.1 explicit Recraft tiers (the SKILL.md mermaid + §1.1
+            # reference these by name; "前者便宜，元件丑陋则用后者").
+            "recraft-4-vector",
+            "recraft-4-vector-pro",
+            # Diffusion / raster providers that go through PNG → SVG.
+            "gemini-imagen-4",
+            "zhipu-cogview-4",
+            "minimax",
+            "gpt-image",
+            # v0.1.1 outline-then-color path (§二 2.x): high-end PNG model
+            # produces line-art only, then Inkscape Trace + manual coloring.
+            # Tracks the source so audit/stats can separate this tier from
+            # full-color diffusion+vectorize rows (very different node counts
+            # and edit-friendliness).
+            "gpt-image2-outline",
+            "gemini-outline",
+            "gpt-image-outline",
+            # Human-authored.
+            "hand-drawn",
+        ],
+        help=("the generator path used to produce this element. "
+              "`*-outline` variants flag the §二 2.x two-stage workflow "
+              "(line-art PNG → vectorize → Inkscape color), so audit/stats "
+              "can report it separately from the standard color-block path."),
+    )
     p_reg.add_argument("--version", default="1", help="version tag (default: 1)")
     p_reg.add_argument("--style-ref", help="style reference filename")
     p_reg.add_argument("--style-id", help="provider-specific style id")

--- a/templates/dark_proteome_4panel_template.svg
+++ b/templates/dark_proteome_4panel_template.svg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template: dark_proteome_4panel_template.svg
+  Purpose : Skeleton for a Nature-Reviews-Drug-Discovery-style 4-panel figure.
+
+  Conventions used by scripts/assemble_figure.py:
+    * Element slots are <rect data-placeholder="ID"> or <g data-placeholder="ID">.
+      Each slot carries x/y/width/height so PNG/EMF fallbacks can reuse the
+      geometry when a non-SVG asset is dropped in.
+    * Text labels are <text id="ID">. The assembler replaces the inner text
+      with manifest.labels[ID].
+    * <title> at the top is for accessibility only (not rewritten); the visible
+      figure title is the <text id="fig-title"> element below it.
+    * viewBox is 1600x1000.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 1600 1000"
+     width="1600" height="1000"
+     font-family="Arial, Helvetica, sans-serif">
+  <title>Figure 1 — 4-panel scientific template</title>
+  <desc>4-panel scientific figure template with placeholder slots and text labels</desc>
+
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#444"/>
+    </marker>
+  </defs>
+
+  <rect width="1600" height="1000" fill="#FFFFFF"/>
+
+  <!-- Visible figure title — replaced by manifest.labels.fig-title -->
+  <text id="fig-title" x="800" y="14" font-size="14" font-weight="700"
+        fill="#1B3A6E" text-anchor="middle">Figure title placeholder</text>
+
+  <!-- ===== PANEL A (top-left) — color theme: blue ===== -->
+  <rect x="20" y="20" width="760" height="440" rx="14"
+        fill="#F2F8FD" stroke="#2E7CD6" stroke-width="0.8"/>
+  <rect x="40" y="38" width="36" height="28" rx="6" fill="#2E7CD6"/>
+  <text x="58" y="58" font-size="18" font-weight="700"
+        fill="#FFFFFF" text-anchor="middle">a</text>
+  <text id="panel-a-title" x="88" y="58" font-size="20"
+        font-weight="700" fill="#1B5BA0">Panel A title</text>
+  <text id="panel-a-subtitle" x="40" y="88" font-size="13"
+        fill="#1B5BA0">Panel A subtitle text</text>
+
+  <text id="panel-a-element-1-label" x="80" y="118" font-size="13"
+        font-weight="600" fill="#333">Element 1 label</text>
+  <rect data-placeholder="panel-a-element-1"
+        x="40" y="130" width="120" height="100" fill="none" stroke="#2E7CD6"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-a-element-2-label" x="240" y="118" font-size="13"
+        font-weight="600" fill="#333">Element 2 label</text>
+  <rect data-placeholder="panel-a-element-2"
+        x="200" y="130" width="160" height="100" fill="none" stroke="#2E7CD6"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-a-element-3-label" x="430" y="118" font-size="13"
+        font-weight="600" fill="#333">Element 3 label (chart area)</text>
+  <rect data-placeholder="panel-a-chart"
+        x="430" y="130" width="240" height="120" fill="none" stroke="#2E7CD6"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-a-row2-label" x="40" y="290" font-size="13"
+        font-weight="600" fill="#333">Row 2 label</text>
+  <rect data-placeholder="panel-a-row2"
+        x="40" y="300" width="320" height="80" fill="none" stroke="#2E7CD6"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-a-feature-label" x="430" y="290" font-size="13"
+        font-weight="600" fill="#333">Features label</text>
+  <g data-placeholder="panel-a-feature-1" transform="translate(465,330)"></g>
+  <text id="panel-a-feature-1-name" x="465" y="380" font-size="10"
+        fill="#444" text-anchor="middle">Feature 1</text>
+  <g data-placeholder="panel-a-feature-2" transform="translate(560,330)"></g>
+  <text id="panel-a-feature-2-name" x="560" y="380" font-size="10"
+        fill="#444" text-anchor="middle">Feature 2</text>
+  <g data-placeholder="panel-a-feature-3" transform="translate(660,330)"></g>
+  <text id="panel-a-feature-3-name" x="660" y="380" font-size="10"
+        fill="#444" text-anchor="middle">Feature 3</text>
+
+  <!-- ===== PANEL B (top-right) — color theme: green ===== -->
+  <rect x="820" y="20" width="760" height="440" rx="14"
+        fill="#F2FAF4" stroke="#4FA85F" stroke-width="0.8"/>
+  <rect x="840" y="38" width="36" height="28" rx="6" fill="#4FA85F"/>
+  <text x="858" y="58" font-size="18" font-weight="700"
+        fill="#FFFFFF" text-anchor="middle">b</text>
+  <text id="panel-b-title" x="888" y="58" font-size="20"
+        font-weight="700" fill="#2E7B3D">Panel B title</text>
+  <text id="panel-b-subtitle" x="840" y="88" font-size="13"
+        fill="#2E7B3D">Panel B subtitle text</text>
+
+  <text id="panel-b-element-1-label" x="840" y="118" font-size="13"
+        font-weight="600" fill="#333">Element 1 label</text>
+  <rect data-placeholder="panel-b-element-1"
+        x="840" y="130" width="320" height="160" fill="none" stroke="#4FA85F"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-b-element-2-label" x="1200" y="118" font-size="13"
+        font-weight="600" fill="#333">Element 2 label</text>
+  <rect data-placeholder="panel-b-element-2"
+        x="1200" y="130" width="340" height="160" fill="none" stroke="#4FA85F"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <text id="panel-b-icons-label" x="840" y="320" font-size="13"
+        font-weight="600" fill="#333">Detection challenges</text>
+  <g data-placeholder="panel-b-icon-1" transform="translate(960,380)"></g>
+  <text id="panel-b-icon-1-name" x="960" y="425" font-size="12"
+        fill="#444" text-anchor="middle">Icon 1</text>
+  <g data-placeholder="panel-b-icon-2" transform="translate(1180,380)"></g>
+  <text id="panel-b-icon-2-name" x="1180" y="425" font-size="12"
+        fill="#444" text-anchor="middle">Icon 2</text>
+  <g data-placeholder="panel-b-icon-3" transform="translate(1400,380)"></g>
+  <text id="panel-b-icon-3-name" x="1400" y="425" font-size="12"
+        fill="#444" text-anchor="middle">Icon 3</text>
+
+  <!-- ===== PANEL C (bottom-left) — color theme: gray ===== -->
+  <rect x="20" y="480" width="760" height="440" rx="14"
+        fill="#F8F8F4" stroke="#888" stroke-width="0.6"/>
+  <rect x="40" y="498" width="36" height="28" rx="6" fill="#5F5E5A"/>
+  <text x="58" y="518" font-size="18" font-weight="700"
+        fill="#FFFFFF" text-anchor="middle">c</text>
+  <text id="panel-c-title" x="88" y="518" font-size="20"
+        font-weight="700" fill="#333">Panel C title</text>
+  <text id="panel-c-subtitle" x="40" y="548" font-size="13"
+        fill="#555">Panel C subtitle text</text>
+
+  <!-- Card grid: 4 cards per row, 2 rows -->
+  <rect data-placeholder="panel-c-card-1"
+        x="40" y="565" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-2"
+        x="220" y="565" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-3"
+        x="400" y="565" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-4"
+        x="580" y="565" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-5"
+        x="40" y="665" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-6"
+        x="220" y="665" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-7"
+        x="400" y="665" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-c-card-8"
+        x="580" y="665" width="170" height="90" fill="none" stroke="#888"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <!-- Bottom highlight box (red border = high-impact) -->
+  <rect x="40" y="775" width="710" height="130" rx="8"
+        fill="#FDF6F4" stroke="#A32D2D" stroke-width="1"/>
+  <rect x="40" y="775" width="710" height="22" rx="8" fill="#A32D2D"/>
+  <text id="panel-c-highlight-title" x="58" y="791"
+        font-size="13" font-weight="700" fill="#FFF">Highlight title</text>
+  <text id="panel-c-highlight-body-1" x="58" y="820"
+        font-size="11" fill="#444">Highlight body line 1</text>
+  <text id="panel-c-highlight-body-2" x="58" y="836"
+        font-size="11" fill="#444">Highlight body line 2</text>
+  <text id="panel-c-highlight-body-3" x="58" y="852"
+        font-size="11" fill="#444">Highlight body line 3</text>
+  <g data-placeholder="panel-c-flow"
+     transform="translate(495,860)"></g>
+
+  <!-- ===== PANEL D (bottom-right) — color theme: purple ===== -->
+  <rect x="820" y="480" width="760" height="440" rx="14"
+        fill="#F7F4FA" stroke="#8B5CB7" stroke-width="0.8"/>
+  <rect x="840" y="498" width="36" height="28" rx="6" fill="#8B5CB7"/>
+  <text x="858" y="518" font-size="18" font-weight="700"
+        fill="#FFFFFF" text-anchor="middle">d</text>
+  <text id="panel-d-title" x="888" y="518" font-size="20"
+        font-weight="700" fill="#6B3F9A">Panel D title</text>
+  <text id="panel-d-subtitle" x="840" y="548" font-size="13"
+        fill="#6B3F9A">Panel D subtitle text</text>
+
+  <rect data-placeholder="panel-d-card-1"
+        x="840" y="575" width="220" height="180" fill="none" stroke="#8B5CB7"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-d-card-2"
+        x="1080" y="575" width="220" height="180" fill="none" stroke="#8B5CB7"
+        stroke-dasharray="3,2" opacity="0.3"/>
+  <rect data-placeholder="panel-d-card-3"
+        x="1320" y="575" width="240" height="180" fill="none" stroke="#8B5CB7"
+        stroke-dasharray="3,2" opacity="0.3"/>
+
+  <rect x="840" y="820" width="720" height="85" rx="8"
+        fill="#F4EBF8" stroke="#8B5CB7" stroke-width="1"/>
+  <rect x="840" y="820" width="720" height="22" rx="8" fill="#8B5CB7"/>
+  <text id="panel-d-summary-title" x="858" y="836"
+        font-size="13" font-weight="700" fill="#FFF">Summary title</text>
+  <text id="panel-d-summary-body" x="858" y="860"
+        font-size="11" fill="#444">Summary body text</text>
+  <g data-placeholder="panel-d-flow"
+     transform="translate(1300,870)"></g>
+
+  <!-- ===== CENTRAL THEME ===== -->
+  <circle cx="800" cy="480" r="92" fill="#FFFFFF"
+          stroke="#1B3A6E" stroke-width="1.4"/>
+  <text id="central-line-1" x="800" y="468" font-size="20"
+        font-weight="700" fill="#1B3A6E" text-anchor="middle">Central</text>
+  <text id="central-line-2" x="800" y="492" font-size="20"
+        font-weight="700" fill="#1B3A6E" text-anchor="middle">theme</text>
+  <text id="central-caption-1" x="800" y="514" font-size="11"
+        fill="#666" text-anchor="middle">Caption line 1</text>
+  <text id="central-caption-2" x="800" y="528" font-size="11"
+        fill="#666" text-anchor="middle">Caption line 2</text>
+
+  <!-- arrows from central to four quadrants -->
+  <line x1="720" y1="430" x2="660" y2="400"
+        stroke="#888" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="880" y1="430" x2="940" y2="400"
+        stroke="#888" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="720" y1="530" x2="660" y2="560"
+        stroke="#888" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="880" y1="530" x2="940" y2="560"
+        stroke="#888" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- ===== LEGEND BAR ===== -->
+  <rect x="20" y="935" width="1560" height="50" rx="8"
+        fill="#FAFAF7" stroke="#DDD" stroke-width="0.5"/>
+  <g data-placeholder="legend-row" transform="translate(30,950)"></g>
+
+</svg>

--- a/templates/dark_proteome_manifest.yaml
+++ b/templates/dark_proteome_manifest.yaml
@@ -1,0 +1,106 @@
+# dark_proteome_manifest.yaml
+# Companion manifest for templates/dark_proteome_4panel_template.svg
+#
+# Workflow:
+#   1. Search elements with `library_tools.py search "alpha helix"` → copy IDs
+#   2. Fill below `panels:` map (placeholder ID → element ID or file path)
+#   3. Run: assemble_figure.py --template ... --manifest this.yaml --output fig.svg
+#
+# Two ways to reference an element:
+#   (A) Unified index ID (recommended after CC0 seed):
+#         panel-a-element-1: bioicons-alpha-helix-cartoon
+#       The script will look it up in ~/sci-illustration-library/library/index.json
+#
+#   (B) File path relative to library_root:
+#         panel-a-element-1: cells/treg-flat-v1.svg
+
+library_root: ~/sci-illustration-library
+
+# ===== ELEMENT SLOTS =====
+# Match keys to data-placeholder= attrs in the template SVG.
+# Replace these example values with real IDs from your library after running:
+#   python library_tools.py search "alpha helix"
+#   python library_tools.py search "T cell"  --license CC0
+panels:
+  # --- Panel A: structurally elusive proteins ---
+  panel-a-element-1:    bioicons-alpha-helix-cartoon       # α-helix folded domain
+  panel-a-element-2:    bioicons-disordered-region         # IDR squiggle
+  panel-a-chart:        manual-charts/protein-length-hist.svg
+  panel-a-row2:         manual-charts/plddt-color-bar.svg
+  panel-a-feature-1:    bioicons-phase-separation-droplet  # phase sep
+  panel-a-feature-2:    bioicons-signaling-hub             # hub network
+  panel-a-feature-3:    bioicons-flexible-binding          # flexible interactions
+
+  # --- Panel B: technically invisible proteins ---
+  panel-b-element-1:    manual-charts/microprotein-length-dist.svg
+  panel-b-element-2:    manual-charts/abundance-vs-msthreshold.svg
+  panel-b-icon-1:       bioicons-test-tube-low             # low expression
+  panel-b-icon-2:       bioicons-mass-spectrum-peaks       # below threshold
+  panel-b-icon-3:       bioicons-confused-protein-magnify  # missed by workflows
+
+  # --- Panel C: non-canonical protein products (8 cards) ---
+  panel-c-card-1:       bioicons-5utr-uorf
+  panel-c-card-2:       bioicons-overlapping-orf
+  panel-c-card-3:       bioicons-3utr-dorf
+  panel-c-card-4:       bioicons-lncrna-sorf
+  panel-c-card-5:       bioicons-circular-rna-sorf
+  panel-c-card-6:       bioicons-pri-mirna-hairpin
+  panel-c-card-7:       bioicons-erv-ltr-gag-pol
+  panel-c-card-8:       bioicons-cryptic-altsplice
+  panel-c-flow:         bioicons-peptide-hla-tcell-flow    # immunotherapy flow
+
+  # --- Panel D: annotation blind spots ---
+  panel-d-card-1:       bioicons-pseudogene-locus-flow
+  panel-d-card-2:       bioicons-te-line-sine-ltr
+  panel-d-card-3:       bioicons-poorly-annotated-orf-cloud
+  panel-d-flow:         bioicons-riboseq-deepms-flow
+
+  # --- Legend ---
+  legend-row:           manual-charts/legend-strip.svg
+
+# ===== TEXT LABELS =====
+# Match keys to id= attrs of <text> elements in the template SVG.
+labels:
+  fig-title: "Figure 1 | The dark proteome"
+
+  # Panel A
+  panel-a-title:    "Structurally elusive proteins"
+  panel-a-subtitle: "Intrinsically disordered proteins (IDPs) & regions (IDRs)"
+  panel-a-element-1-label: "Folded domain"
+  panel-a-element-2-label: "Intrinsically disordered region"
+  panel-a-element-3-label: "Protein length distribution"
+  panel-a-row2-label:      "AlphaFold pLDDT (per-residue confidence)"
+  panel-a-feature-label:   "Key features of IDPs/IDRs"
+  panel-a-feature-1-name:  "Phase separation"
+  panel-a-feature-2-name:  "Signaling hubs"
+  panel-a-feature-3-name:  "Flexible interactions"
+
+  # Panel B
+  panel-b-title:    "Technically invisible proteins"
+  panel-b-subtitle: "Microproteins (<100 aa) & low-abundance species below MS detection limit"
+  panel-b-element-1-label: "Protein length distribution"
+  panel-b-element-2-label: "Abundance vs MS detection threshold"
+  panel-b-icons-label:     "Detection challenges"
+  panel-b-icon-1-name:     "Low expression levels"
+  panel-b-icon-2-name:     "Below detection threshold"
+  panel-b-icon-3-name:     "Missed by standard workflows"
+
+  # Panel C
+  panel-c-title:    "Non-canonical protein products"
+  panel-c-subtitle: "uORFs · alternative reading frames · ERVs · circular / long non-coding RNAs · cryptic regions"
+  panel-c-highlight-title:  "Immunotherapeutic relevance"
+  panel-c-highlight-body-1: "Non-canonical products are tumour-specific (absent from normal self-antigens),"
+  panel-c-highlight-body-2: "HLA-presented, and enriched on malignant cells — priming candidates for"
+  panel-c-highlight-body-3: "T-cell receptor discovery and cancer vaccines."
+
+  # Panel D
+  panel-d-title:    "Annotation blind spots"
+  panel-d-subtitle: "Pseudogene-encoded · transposable element (TE)-derived · poorly annotated proteins"
+  panel-d-summary-title: "Why this matters"
+  panel-d-summary-body:  "Re-annotation with Ribo-seq + deep MS recovers thousands of candidate ORFs."
+
+  # Central
+  central-line-1:    "The"
+  central-line-2:    "dark proteome"
+  central-caption-1: "Proteins that escape"
+  central-caption-2: "conventional proteomic characterization"


### PR DESCRIPTION
## Summary / 概要

Repath the `scientific-illustration-asset-pipeline` skill from v0.1.0 → v0.1.1
based on a real-world failure mode: **Recraft V3 cannot serve as the
whole-figure provider** for scientific figures because diffusion-based output
rasterizes text into 0 `<text>` nodes + 2308 `<path>` nodes (1.8 MB SVG). v0.1.1
switches the whole-figure track to **LLMs writing SVG directly** and bootstraps
a **CC0 element library** (~17 000 elements from 6 public sources) so element
generation no longer burns Recraft credit.

基于一次实战失败模式做路径修正：扩散模型不可能产文字真节点，整图主力改
"LLM 直出 SVG 代码"；同时 bootstrap 一个 CC0 元件库（6 源 ~17000 元件），
元件层不再烧 Recraft credit。

## Field-test data / 实测对比

| Provider | `<text>` nodes | `<path>` nodes | Size |
|---|---|---|---|
| Recraft V3 (diffusion → vectorize) | 0 (text fully blurred) | 2308 | 1.8 MB |
| MiniMax M2.5 (LLM writes SVG) | 142 | 31 | 41 KB |
| Claude (LLM writes SVG) | 166 | 24 | 36.5 KB |

LLM-writes-SVG keeps text as real `<text>` nodes; the failure mode is text
collisions (5–10 min Inkscape touch-up), not unusable rasterized text.

## Files changed / 文件改动

| File | Lines | Reason |
|---|---|---|
| `SKILL.md` | +241 / -14 | v0.1.1 change-summary block, chapter 0 (CC0 bootstrap), §1.0 / 1.0a, Level-3 verdict revision, v0.2 plan |
| `scripts/download_cc0_seed.py` | +796 (new) | 6-source bootstrap downloader |
| `scripts/library_tools.py` | +761 (new) | qc / register / search / audit / check + new stats / preview / export / attribution |
| `scripts/assemble_figure.py` | +316 (new) | template fill + ID resolver + auto attribution |
| `templates/dark_proteome_4panel_template.svg` | +228 (new) | 4-panel 1600×1000 template |
| `templates/dark_proteome_manifest.yaml` | +107 (new) | companion manifest with 26 panels + 33 labels |
| `README.md` | +132 (new) | bootstrap quickstart |
| `openspec/changes/2026-05-sci-illust-v0.1.1.md` | merged on main as part of initial baseline | OpenSpec proposal |

## Audit fixes vs the design zip / 与 design zip 的实测修订

The implementing session ran external API smoke tests and patched several
spec-vs-reality drift items in the same PR:

实施过程跑了外部 API 烟测，发现 spec / 实况偏差并在本 PR 内修订：

1. **PhyloPic v2 API** — added required `embed_items=true`; read absolute SVG
   URLs from `_links.{vectorFile,sourceFile}.href`; pull names from
   `_links.specificNode.title`; honour server-reported `totalPages`.
   PhyloPic v2 API：补 `embed_items=true`、读绝对 SVG URL、用 `_links.specificNode.title` 取名、走 `totalPages` 翻页。
2. **NIH BioArt** — switched from HTTP scrape to manual ZIP ingestion. The
   live site is now a Next.js SPA with no public REST endpoint.
   NIH BioArt：从 HTTP scrape 改成 manual ZIP 注入，站点已是 SPA。
3. **library_tools.py** — dropped unused `Emu` import; hoisted `BytesIO`;
   `tmp_dir` → `tempfile.mkdtemp()` (Windows portability); renamed inner
   `license` loop var to `lic`; widened optional-dep catch to
   `(ImportError, OSError)` so `cairosvg` installed without `libcairo`
   no longer crashes the CLI.
4. **assemble_figure.py** — `copy.deepcopy()` for shared element subtrees;
   reject placeholder/label IDs containing quote/newline chars before xpath.
5. **Template** — added a real `<text id="fig-title">` element; the design
   zip only had `<title id="fig-title">`, which is invisible to the
   assembler's `<svg:text[@id=...]>` xpath.
6. **download_cc0_seed.py** — `_require_runtime_deps()` is lazy so `--help`
   and `--summary-only` work on a fresh box without `requests` etc.

## Validation / 验证

```
[ok] 1) python -c "import ast; ast.parse(...)"  for all 3 .py files
[ok] 2) library_tools.py --help + 9 subcommands all return cleanly
[ok] 3) download_cc0_seed.py --help works without runtime deps
[ok] 4) assemble_figure.py --help works
[ok] 5) lxml.etree.parse(template) ok; yaml.safe_load(manifest) ok
[ok] 6) download_cc0_seed.py --summary-only exits cleanly on empty target
[ok] 7) SKILL.md frontmatter version: 0.1.1; 11 top-level sections
[ok] 8) all 26 manifest.panels keys + 33 manifest.labels keys map to
       existing IDs in the template (27 placeholders, 34 text-ids)
```

## Manual test / 手动测试

```bash
pip install requests beautifulsoup4 lxml tqdm pyyaml \
            cairosvg pillow python-pptx
python scripts/download_cc0_seed.py --summary-only --target /tmp/test
python scripts/library_tools.py stats          # empty library, exits cleanly
python scripts/library_tools.py search foo     # no matches msg
```

Full bootstrap (overnight, ~500 MB):

```bash
python scripts/download_cc0_seed.py --all --target ~/sci-illustration-library
```

## Out of scope (v0.2) / 不在范围

- BioRender connector (待 MCP 工具暴露后单独评估)
- `text_collision_check.py` (auto-detect `<text>` bbox overlaps)
- Library web UI
- Per-journal config (Nature / Cell / Lancet)
- LLM-driven `auto_fill_manifest.py`
- **Low-fidelity tracing layer** — surfaced during this implementation:
  re-trace every CC0 / AI element through Inkscape / Illustrator before
  assembly so visually heterogeneous sources converge to one stylebook,
  then nest into Inkscape / PPT for PDF / SVG-with-nested-SVG output.
  Independent step, orthogonal to v0.1.1's ID-resolver and attribution
  work — promoted to `计划 v0.2` in SKILL.md.

## Test plan / 测试清单

- [x] `python -c "import ast; ast.parse(open(f).read())"` — 3 scripts parse
- [x] `library_tools.py {qc,register,search,audit,check,stats,preview,export,attribution} --help` all return 0
- [x] `download_cc0_seed.py --help` works without runtime deps
- [x] `assemble_figure.py --help` works
- [x] Template SVG parses with `lxml.etree`
- [x] Manifest YAML parses with `yaml.safe_load`
- [x] Every manifest key maps to an existing template ID
- [x] `download_cc0_seed.py --summary-only` exits cleanly on empty target
- [x] `SKILL.md` frontmatter is `version: 0.1.1`, 11 chapters
- [ ] Full overnight bootstrap (user runs: `python scripts/download_cc0_seed.py --all`)
- [ ] End-to-end assemble: search → manifest fill → assemble_figure.py → export PDF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wuyangff95/cc_icons/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->