### PR TITLE
v0.1.2 bulk follow-ups: 9 issues in 10 commits / v0.1.2 批量 follow-up：10 commit 关 9 issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ sci-illustration-library/
 
 # Claude Code session metadata (per-workspace)
 .claude/
+.gstack/

--- a/SKILL.md
+++ b/SKILL.md
@@ -322,8 +322,8 @@ ViewBox 1600×1000. Constraints:
 # Inkscape GUI 微调，5-10 分钟
 inkscape figure.svg
 
-# 或用脚本检测 bbox 冲突（待 v0.2 实现）
-# python scripts/text_collision_check.py figure.svg
+# 或用脚本批量检测 bbox 冲突
+python scripts/text_collision_check.py figure.svg
 ```
 
 ### 1.1 单元件 provider（按元件类型）

--- a/_journal-configs/README.md
+++ b/_journal-configs/README.md
@@ -1,0 +1,64 @@
+# Per-journal figure specs
+
+Each YAML file in this directory codifies one journal's published figure
+requirements (sizes, fonts, line weights, etc.). `assemble_figure.py
+--journal <name>` reads `<name>.yaml` here and validates the output SVG
+against it before declaring success.
+
+每个 YAML 文件编码一个期刊的发表 figure 规范（尺寸 / 字体 / 最小线宽
+等）。`assemble_figure.py --journal <name>` 读取本目录的 `<name>.yaml`
+并在声明成功前对输出 SVG 做校验。
+
+## Schema
+
+```yaml
+name:       Human-readable journal name
+publisher:  Publishing house
+url:        Author guidelines URL (for traceability)
+
+sizes:
+  single_column: { width_mm: 89,  max_height_mm: 220 }
+  double_column: { width_mm: 183, max_height_mm: 240 }
+
+fonts:
+  preferred: [Arial, Helvetica]      # warn if missing
+  forbidden: [Comic Sans, Papyrus]   # fail if found
+
+font_size:
+  min_pt: 7        # element labels
+  max_pt: 12
+
+line_weight:
+  min_pt: 0.5      # minimum stroke width
+
+color_mode: RGB | CMYK
+file_formats: [pdf, eps, ai]
+
+notes: |
+  Any per-journal peculiarities a reader should know about.
+```
+
+## Lookup
+
+`assemble_figure.py --journal nature-reviews-drug-discovery` resolves to
+`_journal-configs/nature-reviews-drug-discovery.yaml`. Names are
+slugified — keep filenames `[a-z0-9-]+`.
+
+## Validation severity
+
+| Field | Violation severity |
+|---|---|
+| `fonts.forbidden` matched | **error** (fail build) |
+| `font_size.min_pt` violated | **error** |
+| `line_weight.min_pt` violated | **error** |
+| `fonts.preferred` not used | warning |
+| `sizes.*` exceeded | warning (depends on journal) |
+
+## Sources
+
+The starter configs in this directory transcribe author-guideline pages
+that were public as of 2026-05. Re-verify against the live page before
+relying on a config for a real submission.
+
+本目录的初始配置是从 2026-05 时公开的 author-guideline 页面转录的。
+真实投稿前请对当时活页面再次核对。

--- a/_journal-configs/cell.yaml
+++ b/_journal-configs/cell.yaml
@@ -3,8 +3,8 @@ publisher: Cell Press / Elsevier
 url: https://www.cell.com/cell/authors
 
 sizes:
-  single_column: { width_mm: 85,  max_height_mm: 225 }
-  double_column: { width_mm: 174, max_height_mm: 225 }
+  single_column: {width_mm: 85,  max_height_mm: 225}
+  double_column: {width_mm: 174, max_height_mm: 225}
 
 fonts:
   preferred: [Arial, Helvetica]

--- a/_journal-configs/cell.yaml
+++ b/_journal-configs/cell.yaml
@@ -1,0 +1,26 @@
+name: Cell
+publisher: Cell Press / Elsevier
+url: https://www.cell.com/cell/authors
+
+sizes:
+  single_column: { width_mm: 85,  max_height_mm: 225 }
+  double_column: { width_mm: 174, max_height_mm: 225 }
+
+fonts:
+  preferred: [Arial, Helvetica]
+  forbidden: [Comic Sans, Papyrus]
+
+font_size:
+  min_pt: 6
+  max_pt: 8
+
+line_weight:
+  min_pt: 0.25
+
+color_mode: RGB
+file_formats: [pdf, eps, ai, tif]
+
+notes: |
+  Cell prefers vector PDF or EPS at 300+ DPI for raster portions. Body
+  text in figures should match Arial 6–8 pt. Multi-panel figures use
+  bold lowercase labels ("a", "b", …) flush left.

--- a/_journal-configs/lancet.yaml
+++ b/_journal-configs/lancet.yaml
@@ -1,0 +1,26 @@
+name: The Lancet
+publisher: Elsevier
+url: https://www.thelancet.com/lancet/information-for-authors
+
+sizes:
+  single_column: { width_mm: 70,  max_height_mm: 230 }
+  double_column: { width_mm: 145, max_height_mm: 230 }
+
+fonts:
+  preferred: [Arial, Helvetica, Univers]
+  forbidden: [Comic Sans, Papyrus]
+
+font_size:
+  min_pt: 7
+  max_pt: 10
+
+line_weight:
+  min_pt: 0.5
+
+color_mode: RGB
+file_formats: [pdf, eps, tif]
+
+notes: |
+  The Lancet uses narrower columns than most journals (single 70 mm,
+  double 145 mm). Clinical figures often include a forest plot or flow
+  diagram; both should remain readable at 70 mm width. Vector preferred.

--- a/_journal-configs/lancet.yaml
+++ b/_journal-configs/lancet.yaml
@@ -3,8 +3,8 @@ publisher: Elsevier
 url: https://www.thelancet.com/lancet/information-for-authors
 
 sizes:
-  single_column: { width_mm: 70,  max_height_mm: 230 }
-  double_column: { width_mm: 145, max_height_mm: 230 }
+  single_column: {width_mm: 70,  max_height_mm: 230}
+  double_column: {width_mm: 145, max_height_mm: 230}
 
 fonts:
   preferred: [Arial, Helvetica, Univers]

--- a/_journal-configs/nature-reviews-drug-discovery.yaml
+++ b/_journal-configs/nature-reviews-drug-discovery.yaml
@@ -1,0 +1,28 @@
+name: Nature Reviews Drug Discovery
+publisher: Springer Nature
+url: https://www.nature.com/nrd/about/figure-guide
+
+sizes:
+  single_column: { width_mm: 88,  max_height_mm: 240 }
+  double_column: { width_mm: 180, max_height_mm: 240 }
+
+fonts:
+  preferred: [Arial, Helvetica]
+  forbidden: [Comic Sans, Papyrus, Wingdings]
+
+font_size:
+  min_pt: 6
+  max_pt: 12
+
+line_weight:
+  min_pt: 0.5
+
+color_mode: RGB
+file_formats: [pdf, eps, ai]
+
+notes: |
+  Nature Reviews journals use a layout-heavy style (4-panel Fig1 with
+  central theme, color-coded panels, legend strip — exactly the layout
+  the dark_proteome template targets). Sans-serif throughout, color
+  palette restricted, panel labels (a/b/c/d) in bold. Schemes preferred
+  over photos; vector preferred over raster.

--- a/_journal-configs/nature-reviews-drug-discovery.yaml
+++ b/_journal-configs/nature-reviews-drug-discovery.yaml
@@ -3,8 +3,8 @@ publisher: Springer Nature
 url: https://www.nature.com/nrd/about/figure-guide
 
 sizes:
-  single_column: { width_mm: 88,  max_height_mm: 240 }
-  double_column: { width_mm: 180, max_height_mm: 240 }
+  single_column: {width_mm: 88,  max_height_mm: 240}
+  double_column: {width_mm: 180, max_height_mm: 240}
 
 fonts:
   preferred: [Arial, Helvetica]

--- a/_journal-configs/nature.yaml
+++ b/_journal-configs/nature.yaml
@@ -1,0 +1,27 @@
+name: Nature
+publisher: Springer Nature
+url: https://www.nature.com/nature/for-authors/final-submission
+
+sizes:
+  single_column: { width_mm: 89,  max_height_mm: 247 }
+  double_column: { width_mm: 183, max_height_mm: 247 }
+
+fonts:
+  preferred: [Arial, Helvetica]
+  forbidden: [Comic Sans, Papyrus, Wingdings]
+
+font_size:
+  min_pt: 5
+  max_pt: 7
+
+line_weight:
+  min_pt: 0.25
+
+color_mode: RGB
+file_formats: [pdf, eps, ai, tif]
+
+notes: |
+  Nature accepts vector figures only; embed a 300+ DPI raster only when
+  the asset is intrinsically raster (microscopy, photo). Use Arial
+  throughout. Final figures are typeset to single (89 mm) or double
+  (183 mm) column width. Keep line weights ≥ 0.25 pt at final size.

--- a/_journal-configs/nature.yaml
+++ b/_journal-configs/nature.yaml
@@ -3,8 +3,8 @@ publisher: Springer Nature
 url: https://www.nature.com/nature/for-authors/final-submission
 
 sizes:
-  single_column: { width_mm: 89,  max_height_mm: 247 }
-  double_column: { width_mm: 183, max_height_mm: 247 }
+  single_column: {width_mm: 89,  max_height_mm: 247}
+  double_column: {width_mm: 183, max_height_mm: 247}
 
 fonts:
   preferred: [Arial, Helvetica]

--- a/_journal-configs/nejm.yaml
+++ b/_journal-configs/nejm.yaml
@@ -1,0 +1,27 @@
+name: New England Journal of Medicine
+publisher: Massachusetts Medical Society
+url: https://www.nejm.org/author-center
+
+sizes:
+  single_column: { width_mm: 80,  max_height_mm: 230 }
+  double_column: { width_mm: 165, max_height_mm: 230 }
+
+fonts:
+  preferred: [Helvetica, Arial]
+  forbidden: [Comic Sans, Papyrus]
+
+font_size:
+  min_pt: 7
+  max_pt: 10
+
+line_weight:
+  min_pt: 0.5
+
+color_mode: RGB
+file_formats: [pdf, eps, tif, ai]
+
+notes: |
+  NEJM redraws all figures in-house from author-supplied source files,
+  so consistency with the journal style is less critical than legibility
+  and clinical accuracy at the supplied final size. Provide editable
+  vector wherever possible (PDF / EPS / AI).

--- a/_journal-configs/nejm.yaml
+++ b/_journal-configs/nejm.yaml
@@ -3,8 +3,8 @@ publisher: Massachusetts Medical Society
 url: https://www.nejm.org/author-center
 
 sizes:
-  single_column: { width_mm: 80,  max_height_mm: 230 }
-  double_column: { width_mm: 165, max_height_mm: 230 }
+  single_column: {width_mm: 80,  max_height_mm: 230}
+  double_column: {width_mm: 165, max_height_mm: 230}
 
 fonts:
   preferred: [Helvetica, Arial]

--- a/_journal-configs/science.yaml
+++ b/_journal-configs/science.yaml
@@ -1,0 +1,27 @@
+name: Science
+publisher: AAAS
+url: https://www.science.org/content/page/instructions-preparing-initial-manuscript
+
+sizes:
+  single_column: { width_mm: 55,  max_height_mm: 240 }
+  double_column: { width_mm: 120, max_height_mm: 240 }
+  page_width:    { width_mm: 183, max_height_mm: 240 }
+
+fonts:
+  preferred: [Helvetica, Arial]
+  forbidden: [Comic Sans, Papyrus]
+
+font_size:
+  min_pt: 5
+  max_pt: 8
+
+line_weight:
+  min_pt: 0.5
+
+color_mode: RGB
+file_formats: [pdf, ai, eps, tif]
+
+notes: |
+  Science uses three width tiers (55 / 120 / 183 mm). Helvetica is
+  the preferred sans-serif. Multi-panel figures use bold uppercase
+  labels ("A", "B", …). Schematic line weights ≥ 0.5 pt at final size.

--- a/_journal-configs/science.yaml
+++ b/_journal-configs/science.yaml
@@ -3,9 +3,9 @@ publisher: AAAS
 url: https://www.science.org/content/page/instructions-preparing-initial-manuscript
 
 sizes:
-  single_column: { width_mm: 55,  max_height_mm: 240 }
-  double_column: { width_mm: 120, max_height_mm: 240 }
-  page_width:    { width_mm: 183, max_height_mm: 240 }
+  single_column: {width_mm: 55,  max_height_mm: 240}
+  double_column: {width_mm: 120, max_height_mm: 240}
+  page_width:    {width_mm: 183, max_height_mm: 240}
 
 fonts:
   preferred: [Helvetica, Arial]

--- a/_palettes/README.md
+++ b/_palettes/README.md
@@ -1,0 +1,34 @@
+# Project palettes
+
+Each YAML file here is a list of hex swatches that
+`scripts/lowfi_trace.py --palette <file>` will snap every `fill` /
+`stroke` / `stop-color` to. The starter palettes match the
+`dark_proteome_4panel_template.svg` panel headers — pick one closest to
+your project's visual direction and edit.
+
+每份 YAML 是一组 hex 色板，`scripts/lowfi_trace.py --palette <file>`
+会把所有 `fill` / `stroke` / `stop-color` 吸附到色板中最近的色。起步
+色板对齐 `dark_proteome_4panel_template.svg` 的面板头颜色 —— 选最贴
+近你项目视觉方向的，再按需改。
+
+## Schema
+
+```yaml
+name: Human-readable palette name
+notes: |
+  Where this palette comes from and what it's good for.
+colors:
+  - "#1B5BA0"
+  - "#2E7CD6"
+  - ...
+```
+
+## Pick by panel
+
+- **nature-flat-blue**: cool blue-only, Nature-style schematics
+- **dark-proteome-mixed**: blue + green + gray + purple (matches the
+  bundled 4-panel template)
+- **clinical-warm**: warm grays for clinical / NEJM-leaning figures
+
+To add your own, drop a new YAML following the schema above. Names are
+slugified — keep filenames `[a-z0-9-]+`.

--- a/_palettes/dark-proteome-mixed.yaml
+++ b/_palettes/dark-proteome-mixed.yaml
@@ -1,0 +1,29 @@
+name: Dark Proteome (4-panel mixed)
+notes: |
+  The native palette of `templates/dark_proteome_4panel_template.svg`.
+  4 panel themes (blue / green / gray / purple) + neutrals + a single
+  red highlight for "high-impact" callouts.
+colors:
+  # Panel A — blue
+  - "#2E7CD6"
+  - "#1B5BA0"
+  - "#F2F8FD"
+  # Panel B — green
+  - "#4FA85F"
+  - "#2E7B3D"
+  - "#F2FAF4"
+  # Panel C — gray
+  - "#888888"
+  - "#5F5E5A"
+  - "#F8F8F4"
+  # Panel D — purple
+  - "#8B5CB7"
+  - "#6B3F9A"
+  - "#F7F4FA"
+  # High-impact red callout
+  - "#A32D2D"
+  - "#FDF6F4"
+  # Neutrals
+  - "#FFFFFF"
+  - "#333333"
+  - "#1B3A6E"

--- a/_palettes/nature-flat-blue.yaml
+++ b/_palettes/nature-flat-blue.yaml
@@ -1,0 +1,15 @@
+name: Nature Flat Blue
+notes: |
+  Cool blue-only palette for Nature-style schematics. Pair with
+  `--font Arial` and `--journal nature` in assemble_figure.py.
+colors:
+  - "#0D3B73"
+  - "#1B5BA0"
+  - "#2E7CD6"
+  - "#5DA0E6"
+  - "#A6CFF2"
+  - "#E1EDFA"
+  - "#F2F8FD"
+  - "#FFFFFF"
+  - "#333333"
+  - "#888888"

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -564,6 +564,159 @@ def export_pptx(svg_path: Path, pptx_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-journal validation
+# ---------------------------------------------------------------------------
+
+
+def _journal_config_dir(start: Path) -> Path:
+    """Locate `_journal-configs/` by walking up from the script's location.
+
+    Returns the first existing `_journal-configs/` directory found by walking
+    parents up to the repo root, or a sensible default if none exists.
+    """
+    cur = start.resolve()
+    for _ in range(6):
+        candidate = cur / "_journal-configs"
+        if candidate.is_dir():
+            return candidate
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return start / "_journal-configs"  # default; load_journal_config will error
+
+
+def load_journal_config(name: str, search_root: Path | None = None) -> dict:
+    """Load `<name>.yaml` from `_journal-configs/` and validate the schema."""
+    cfg_dir = _journal_config_dir(search_root or Path(__file__).parent)
+    cfg_path = cfg_dir / f"{name}.yaml"
+    if not cfg_path.exists():
+        available = sorted(p.stem for p in cfg_dir.glob("*.yaml") if p.stem != "README")
+        raise FileNotFoundError(
+            f"Journal config not found: {cfg_path}\n"
+            f"Available: {', '.join(available) if available else '(none)'}"
+        )
+    cfg = yaml.safe_load(cfg_path.read_text()) or {}
+    if not isinstance(cfg, dict) or "name" not in cfg:
+        raise ValueError(f"{cfg_path} is not a valid journal config")
+    return cfg
+
+
+def _iter_text_elements(root: etree._Element):
+    """Yield every `<text>` and `<tspan>` descendant."""
+    text_tags = {f"{SVG_TAG}text", f"{SVG_TAG}tspan"}
+    for elem in root.iter():
+        if elem.tag in text_tags:
+            yield elem
+
+
+def _get_inherited_attr(elem: etree._Element, attr: str) -> str | None:
+    """Walk the parent chain looking for an attribute."""
+    cur: etree._Element | None = elem
+    while cur is not None:
+        val = cur.get(attr)
+        if val:
+            return val
+        cur = cur.getparent()
+    return None
+
+
+def _parse_pt(value: str | None) -> float | None:
+    """Convert a CSS-ish font-size to pt (1pt ≈ 1.333 px)."""
+    if not value:
+        return None
+    s = value.strip().lower()
+    try:
+        if s.endswith("pt"):
+            return float(s[:-2])
+        if s.endswith("px"):
+            return float(s[:-2]) * 0.75  # px → pt
+        if s.endswith("mm"):
+            return float(s[:-2]) * 2.834645669
+        if s.endswith("pc"):
+            return float(s[:-2]) * 12.0
+        # bare number — treat as user units (~px in our templates)
+        return float(s) * 0.75
+    except ValueError:
+        return None
+
+
+def validate_against_journal(svg_path: Path, journal_cfg: dict) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) — errors fail the build, warnings just print.
+
+    Checks:
+      - fonts.forbidden present anywhere → error
+      - fonts.preferred not used anywhere → warning
+      - font_size.min_pt / max_pt violated → error / warning
+      - line_weight.min_pt violated → error
+      - sizes.* exceeded → warning
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        tree = etree.parse(str(svg_path))
+    except (etree.XMLSyntaxError, etree.ParseError, OSError) as exc:
+        return ([f"could not parse SVG: {exc}"], [])
+    root = tree.getroot()
+
+    fonts_cfg = journal_cfg.get("fonts") or {}
+    forbidden = {f.lower() for f in fonts_cfg.get("forbidden", [])}
+    preferred = {f.lower() for f in fonts_cfg.get("preferred", [])}
+    fs_cfg = journal_cfg.get("font_size") or {}
+    min_pt = float(fs_cfg.get("min_pt", 0))
+    max_pt = float(fs_cfg.get("max_pt", 9999))
+    lw_cfg = journal_cfg.get("line_weight") or {}
+    min_lw_pt = float(lw_cfg.get("min_pt", 0))
+
+    used_fonts: set[str] = set()
+
+    # Text-bearing elements: font + size checks.
+    for elem in _iter_text_elements(root):
+        ff = (_get_inherited_attr(elem, "font-family") or "").strip().strip('"\'')
+        if ff:
+            for chunk in ff.split(","):
+                used_fonts.add(chunk.strip().strip('"\'').lower())
+        fs_raw = _get_inherited_attr(elem, "font-size")
+        fs_pt = _parse_pt(fs_raw)
+        if fs_pt is not None:
+            if fs_pt < min_pt:
+                errors.append(f"<{elem.tag.split('}')[-1]} id={elem.get('id')!r}>"
+                              f" font-size {fs_pt:.1f}pt < {min_pt}pt min")
+            if fs_pt > max_pt:
+                warnings.append(f"<{elem.tag.split('}')[-1]} id={elem.get('id')!r}>"
+                                f" font-size {fs_pt:.1f}pt > {max_pt}pt max")
+
+    # Substring match so the config can list canonical names like
+    # "Comic Sans" while the SVG carries the OS-specific variant
+    # "Comic Sans MS". Same logic for preferred matching.
+    forbidden_hits = {
+        bad for bad in forbidden
+        if any(bad in used for used in used_fonts)
+    }
+    if forbidden_hits:
+        errors.append(f"forbidden fonts present: {sorted(forbidden_hits)} "
+                      f"(matched in: {sorted(used_fonts)})")
+    if preferred:
+        any_preferred_used = any(
+            pref in used for pref in preferred for used in used_fonts
+        )
+        if not any_preferred_used:
+            warnings.append(f"none of the preferred fonts {sorted(preferred)} "
+                            f"were used (found: {sorted(used_fonts)})")
+
+    # Stroke widths.
+    for elem in root.iter():
+        sw_raw = elem.get("stroke-width")
+        sw_pt = _parse_pt(sw_raw)
+        if sw_pt is not None and 0 < sw_pt < min_lw_pt:
+            tag = elem.tag.split("}")[-1]
+            errors.append(f"<{tag} id={elem.get('id')!r}> "
+                          f"stroke-width {sw_pt:.2f}pt < {min_lw_pt}pt min")
+
+    return errors, warnings
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -574,6 +727,9 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, required=True, help="manifest YAML")
     parser.add_argument("--output", type=Path, required=True, help="output SVG path")
     parser.add_argument("--font", default="Arial", help="unified font-family (default: Arial)")
+    parser.add_argument("--journal", type=str, default=None,
+                        help=("validate the output against `_journal-configs/<name>.yaml` "
+                              "(e.g. 'nature', 'cell', 'lancet'). Build fails on any error."))
     parser.add_argument("--export-pdf", action="store_true",
                         help="export an editable PDF alongside the SVG")
     parser.add_argument("--export-pdf-final", action="store_true",
@@ -594,6 +750,29 @@ def main() -> int:
 
     fill_placeholders(args.template, manifest, args.output)
     normalize_fonts(args.output, args.font)
+
+    # Run journal validation BEFORE the (more expensive) export step so the
+    # user sees violations early. Errors fail the build with non-zero exit.
+    if args.journal:
+        try:
+            cfg = load_journal_config(args.journal)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        errors, warnings = validate_against_journal(args.output, cfg)
+        if warnings:
+            print(f"\n[journal:{cfg['name']}] warnings ({len(warnings)}):", file=sys.stderr)
+            for w in warnings:
+                print(f"  - {w}", file=sys.stderr)
+        if errors:
+            print(f"\n[journal:{cfg['name']}] errors ({len(errors)}):", file=sys.stderr)
+            for e in errors:
+                print(f"  - {e}", file=sys.stderr)
+            print("\nFix the errors above or remove --journal to bypass.",
+                  file=sys.stderr)
+            return 1
+        if not warnings and not errors:
+            print(f"\n[journal:{cfg['name']}] ✓ all checks passed")
 
     if args.export_pdf:
         export_pdf(

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -604,6 +604,28 @@ def load_journal_config(name: str, search_root: Path | None = None) -> dict:
     cfg = yaml.safe_load(cfg_path.read_text()) or {}
     if not isinstance(cfg, dict) or "name" not in cfg:
         raise ValueError(f"{cfg_path} is not a valid journal config")
+
+    # Numeric-field schema check — a typo like `min_pt: "8pt"` in a
+    # hand-edited YAML would otherwise crash at validation time with a
+    # confusing `float()` ValueError instead of a useful message
+    # pointing at the bad field path.
+    def _require_number(path: str, value: object) -> None:
+        if value is None:
+            return
+        try:
+            float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{cfg_path}: `{path}` must be numeric, got {value!r}"
+            ) from exc
+
+    _require_number("font_size.min_pt", (cfg.get("font_size") or {}).get("min_pt"))
+    _require_number("font_size.max_pt", (cfg.get("font_size") or {}).get("max_pt"))
+    _require_number("line_weight.min_pt", (cfg.get("line_weight") or {}).get("min_pt"))
+    for col_name, col_cfg in (cfg.get("sizes") or {}).items():
+        if isinstance(col_cfg, dict):
+            _require_number(f"sizes.{col_name}.width_mm", col_cfg.get("width_mm"))
+            _require_number(f"sizes.{col_name}.max_height_mm", col_cfg.get("max_height_mm"))
     return cfg
 
 
@@ -768,21 +790,32 @@ def validate_against_journal(svg_path: Path, journal_cfg: dict) -> tuple[list[st
                 except ValueError:
                     pass
         if canvas_w_mm is not None and canvas_h_mm is not None:
+            # A figure is acceptable if it fits AT LEAST ONE configured
+            # column tier (single / double / page-width). Warning only
+            # fires when it overflows EVERY tier — otherwise an 18 cm
+            # double-column figure would be flagged as "exceeds 9 cm
+            # single-column" which is a false positive.
+            fits_any = False
+            tier_misses: list[str] = []
             for col_name, col_cfg in sizes_cfg.items():
                 if not isinstance(col_cfg, dict):
                     continue
                 w_max = col_cfg.get("width_mm")
                 h_max = col_cfg.get("max_height_mm")
-                if w_max and canvas_w_mm > float(w_max):
-                    warnings.append(
-                        f"canvas width {canvas_w_mm:.1f}mm > "
-                        f"{col_name}.width_mm={w_max}"
-                    )
-                if h_max and canvas_h_mm > float(h_max):
-                    warnings.append(
-                        f"canvas height {canvas_h_mm:.1f}mm > "
-                        f"{col_name}.max_height_mm={h_max}"
-                    )
+                w_ok = (w_max is None) or (canvas_w_mm <= float(w_max))
+                h_ok = (h_max is None) or (canvas_h_mm <= float(h_max))
+                if w_ok and h_ok:
+                    fits_any = True
+                    break
+                tier_misses.append(
+                    f"{col_name} ({canvas_w_mm:.1f}mm × {canvas_h_mm:.1f}mm "
+                    f"vs {w_max}mm × {h_max}mm)"
+                )
+            if not fits_any and tier_misses:
+                warnings.append(
+                    "canvas exceeds every configured size tier: "
+                    + "; ".join(tier_misses)
+                )
 
     return errors, warnings
 

--- a/scripts/assemble_figure.py
+++ b/scripts/assemble_figure.py
@@ -586,9 +586,15 @@ def _journal_config_dir(start: Path) -> Path:
 
 
 def load_journal_config(name: str, search_root: Path | None = None) -> dict:
-    """Load `<name>.yaml` from `_journal-configs/` and validate the schema."""
+    """Load `<name>.yaml` from `_journal-configs/` and validate the schema.
+
+    `name` is slugified before lookup so callers can pass either the
+    canonical filename (`nature-reviews-drug-discovery`) or the human form
+    (`Nature Reviews Drug Discovery`) — both resolve to the same file.
+    """
     cfg_dir = _journal_config_dir(search_root or Path(__file__).parent)
-    cfg_path = cfg_dir / f"{name}.yaml"
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    cfg_path = cfg_dir / f"{slug}.yaml"
     if not cfg_path.exists():
         available = sorted(p.stem for p in cfg_dir.glob("*.yaml") if p.stem != "README")
         raise FileNotFoundError(
@@ -610,12 +616,26 @@ def _iter_text_elements(root: etree._Element):
 
 
 def _get_inherited_attr(elem: etree._Element, attr: str) -> str | None:
-    """Walk the parent chain looking for an attribute."""
+    """Walk the parent chain looking for an SVG presentation value.
+
+    Looks at both the explicit attribute (e.g. ``font-family="Arial"``) and
+    the inline ``style="..."`` declaration (``style="font-family:Arial;..."``).
+    Real-world SVGs from Inkscape, Affinity, Illustrator, etc. routinely
+    declare presentation values inline rather than as attributes — without
+    this, journal validation silently misses forbidden fonts and floor
+    violations that live inside ``style=``.
+    """
     cur: etree._Element | None = elem
     while cur is not None:
         val = cur.get(attr)
         if val:
             return val
+        style = cur.get("style") or ""
+        if attr in style:
+            for chunk in style.split(";"):
+                key, _, value = chunk.partition(":")
+                if key.strip() == attr and value.strip():
+                    return value.strip()
         cur = cur.getparent()
     return None
 
@@ -704,14 +724,65 @@ def validate_against_journal(svg_path: Path, journal_cfg: dict) -> tuple[list[st
             warnings.append(f"none of the preferred fonts {sorted(preferred)} "
                             f"were used (found: {sorted(used_fonts)})")
 
-    # Stroke widths.
+    # Stroke widths. Use the same presentation-attribute walker so values
+    # in `style="stroke-width:..."` and parent-chain inheritance are caught.
     for elem in root.iter():
-        sw_raw = elem.get("stroke-width")
+        sw_raw = _get_inherited_attr(elem, "stroke-width")
         sw_pt = _parse_pt(sw_raw)
         if sw_pt is not None and 0 < sw_pt < min_lw_pt:
             tag = elem.tag.split("}")[-1]
             errors.append(f"<{tag} id={elem.get('id')!r}> "
                           f"stroke-width {sw_pt:.2f}pt < {min_lw_pt}pt min")
+
+    # Canvas size limits. Read width / height attributes if present, else
+    # derive from viewBox. Compare against `sizes.<col>.{width_mm,
+    # max_height_mm}` and warn when any column exceeds the limit.
+    sizes_cfg = journal_cfg.get("sizes") or {}
+    if sizes_cfg:
+        # We treat user units as ~mm at the journal's intended print size
+        # (templates are typically authored at 1u ≈ 1mm). Honour explicit
+        # `width="...mm"` first; else fall back to viewBox.
+        canvas_w_mm: float | None = None
+        canvas_h_mm: float | None = None
+        w_raw = root.get("width") or ""
+        h_raw = root.get("height") or ""
+        if w_raw.endswith("mm"):
+            try:
+                canvas_w_mm = float(w_raw[:-2])
+            except ValueError:
+                pass
+        if h_raw.endswith("mm"):
+            try:
+                canvas_h_mm = float(h_raw[:-2])
+            except ValueError:
+                pass
+        if canvas_w_mm is None or canvas_h_mm is None:
+            vb_raw = (root.get("viewBox") or "").strip()
+            vb = [v for v in re.split(r"[\s,]+", vb_raw) if v]
+            if len(vb) >= 4:
+                try:
+                    if canvas_w_mm is None:
+                        canvas_w_mm = float(vb[2])
+                    if canvas_h_mm is None:
+                        canvas_h_mm = float(vb[3])
+                except ValueError:
+                    pass
+        if canvas_w_mm is not None and canvas_h_mm is not None:
+            for col_name, col_cfg in sizes_cfg.items():
+                if not isinstance(col_cfg, dict):
+                    continue
+                w_max = col_cfg.get("width_mm")
+                h_max = col_cfg.get("max_height_mm")
+                if w_max and canvas_w_mm > float(w_max):
+                    warnings.append(
+                        f"canvas width {canvas_w_mm:.1f}mm > "
+                        f"{col_name}.width_mm={w_max}"
+                    )
+                if h_max and canvas_h_mm > float(h_max):
+                    warnings.append(
+                        f"canvas height {canvas_h_mm:.1f}mm > "
+                        f"{col_name}.max_height_mm={h_max}"
+                    )
 
     return errors, warnings
 

--- a/scripts/auto_fill_manifest.py
+++ b/scripts/auto_fill_manifest.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+auto_fill_manifest.py — generate a manifest YAML from a project description.
+
+Today's flow: user reads the SVG template, lists every `data-placeholder`
+id, then picks an element id for each via `library_tools.py search`.
+26-placeholder templates like dark_proteome are tedious by hand.
+
+This script automates step 1 + step 2:
+
+  1. Parse the SVG template — extract every `data-placeholder` id and
+     `<text id=>` id with positional context.
+  2. Send the description + the placeholder list to a (provider-
+     agnostic) LLM, asking it to propose a one-line semantics for
+     each placeholder + a string for each label.
+  3. For each proposed semantics, run `library_tools.py search` style
+     matching against the unified index to get candidate ids; take
+     the top hit (or surface ambiguity).
+  4. Emit `manifest.yaml` with the picks.
+
+Provider:
+  - `--llm-mode mock` (default): no API key needed. Generates a
+    placeholder-id-keyed manifest with empty values + a "TODO" comment
+    block listing every placeholder so the user can fill in. Useful as a
+    skeleton scaffolder while the live LLM call is wired up.
+  - `--llm-mode live` + appropriate `*_API_KEY` env var: invokes the
+    chosen provider via the official SDK if installed. Implementation
+    deferred behind `NotImplementedError` until the user picks a
+    canonical provider for this skill (likely MiniMax per SKILL.md
+    §1.0a — same default as for whole-figure SVG writing).
+
+Always preview with `--dry-run` first to see the LLM's proposals before
+they hit disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from lxml import etree
+
+
+SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+
+
+# ---------------------------------------------------------------------------
+# Template parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Placeholder:
+    """A `<… data-placeholder="ID" x= y= width= height=>` slot."""
+    placeholder_id: str
+    tag: str
+    x: float
+    y: float
+    width: float
+    height: float
+
+    @property
+    def panel_letter(self) -> str | None:
+        """Best-effort 'a/b/c/d' from `panel-X-…` ids."""
+        m = re.match(r"panel-([a-z])-", self.placeholder_id)
+        return m.group(1) if m else None
+
+
+@dataclass(frozen=True)
+class Label:
+    """A `<text id="ID">` or `<tspan id="ID">` element waiting for content."""
+    label_id: str
+    x: float | None
+    y: float | None
+    placeholder_text: str  # what the template currently shows
+
+
+def parse_template(template_path: Path) -> tuple[list[Placeholder], list[Label]]:
+    """Walk the SVG once; return the lists of placeholders and labels."""
+    tree = etree.parse(str(template_path))
+    root = tree.getroot()
+
+    placeholders: list[Placeholder] = []
+    for elem in root.xpath('.//svg:*[@data-placeholder]', namespaces=SVG_NS):
+        try:
+            ph = Placeholder(
+                placeholder_id=elem.get("data-placeholder"),
+                tag=etree.QName(elem.tag).localname,
+                x=float(elem.get("x") or 0.0),
+                y=float(elem.get("y") or 0.0),
+                width=float(elem.get("width") or 0.0),
+                height=float(elem.get("height") or 0.0),
+            )
+        except (ValueError, TypeError):
+            continue
+        placeholders.append(ph)
+
+    labels: list[Label] = []
+    for tag in ("svg:text", "svg:tspan"):
+        for elem in root.xpath(f'.//{tag}[@id]', namespaces=SVG_NS):
+            text = (elem.text or "").strip()
+            if not text:
+                # skip unlabeled <tspan> wrappers
+                continue
+            try:
+                x_raw = elem.get("x"); y_raw = elem.get("y")
+                x_v = float(x_raw) if x_raw else None
+                y_v = float(y_raw) if y_raw else None
+            except ValueError:
+                x_v = y_v = None
+            labels.append(Label(
+                label_id=elem.get("id"),
+                x=x_v, y=y_v,
+                placeholder_text=text[:120],
+            ))
+    return placeholders, labels
+
+
+# ---------------------------------------------------------------------------
+# Library lookup
+# ---------------------------------------------------------------------------
+
+
+def load_library_records(library_root: Path) -> list[dict]:
+    """Same minimal index walk as library_tools.load_unified_index."""
+    records: list[dict] = []
+    json_idx = library_root / "library" / "index.json"
+    if json_idx.exists():
+        try:
+            data = json.loads(json_idx.read_text())
+            records.extend(r for r in data if r.get("id"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    # We skip legacy YAML for simplicity — the JSON bulk index covers the
+    # bootstrap-fed CC0 library, which is the realistic input here.
+    return records
+
+
+def search_library(records: list[dict], semantics: str) -> str | None:
+    """Return the best-matching record id, or None."""
+    if not semantics:
+        return None
+    query = semantics.lower().strip()
+    # Score by # of query tokens that hit name + category + tags.
+    tokens = [t for t in re.split(r"[\s\-_/]+", query) if len(t) > 2]
+    best: tuple[int, dict] | None = None
+    for r in records:
+        haystack = " ".join([
+            (r.get("name") or "").lower(),
+            (r.get("category") or "").lower(),
+            " ".join(r.get("tags", [])).lower(),
+            (r.get("id") or "").lower(),
+        ])
+        score = sum(1 for t in tokens if t in haystack)
+        if score == 0:
+            continue
+        if best is None or score > best[0]:
+            best = (score, r)
+    return best[1]["id"] if best else None
+
+
+# ---------------------------------------------------------------------------
+# Semantics propose: mock + live
+# ---------------------------------------------------------------------------
+
+
+def propose_semantics_mock(
+    description: str,
+    placeholders: list[Placeholder],
+    labels: list[Label],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Mock provider: scaffold a manifest skeleton for the user to fill in.
+
+    For each placeholder it derives a TODO marker that includes the panel
+    letter and a hint extracted from the description's first sentence; for
+    each label it leaves the original placeholder text as a starting point.
+    """
+    first_sentence = re.split(r"[.。!?\n]", description.strip(), maxsplit=1)[0]
+    hint = first_sentence[:80] if first_sentence else "describe element"
+
+    panels: dict[str, str] = {}
+    for ph in placeholders:
+        panel_hint = f"[panel {ph.panel_letter}] " if ph.panel_letter else ""
+        panels[ph.placeholder_id] = f"# TODO: {panel_hint}{hint}"
+
+    labels_out: dict[str, str] = {}
+    for lb in labels:
+        labels_out[lb.label_id] = lb.placeholder_text  # keep template default
+    return panels, labels_out
+
+
+def propose_semantics_live(
+    description: str,
+    placeholders: list[Placeholder],
+    labels: list[Label],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Live LLM call. Deferred — see issue #3 / #9 for the wiring TODO."""
+    raise NotImplementedError(
+        "Live LLM call not yet wired up. Use --llm-mode mock for the scaffold "
+        "today; the live mode will land once we pick a canonical provider for "
+        "this skill (likely MiniMax per SKILL.md §1.0a)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest writer
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    library_root: Path,
+    placeholders: list[Placeholder],
+    labels: list[Label],
+    semantics_panels: dict[str, str],
+    semantics_labels: dict[str, str],
+    records: list[dict],
+) -> dict:
+    """Assemble the final manifest dict, resolving each semantics to an element id."""
+    panels_resolved: dict[str, str] = {}
+    todo_notes: dict[str, str] = {}
+
+    for ph in placeholders:
+        proposed = semantics_panels.get(ph.placeholder_id, "")
+        if proposed.startswith("# TODO"):
+            todo_notes[ph.placeholder_id] = proposed
+            panels_resolved[ph.placeholder_id] = ""
+            continue
+        match = search_library(records, proposed)
+        if match:
+            panels_resolved[ph.placeholder_id] = match
+        else:
+            todo_notes[ph.placeholder_id] = (
+                f"# UNRESOLVED: '{proposed}' — no library hit"
+            )
+            panels_resolved[ph.placeholder_id] = ""
+
+    return {
+        "library_root": str(library_root),
+        "_auto_fill_notes": todo_notes,
+        "panels": panels_resolved,
+        "labels": semantics_labels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a manifest YAML from a SVG template + project description.",
+    )
+    parser.add_argument("--template", type=Path, required=True,
+                        help="SVG template with data-placeholder + text id slots")
+    parser.add_argument("--description", type=str, default=None,
+                        help="one-paragraph project description (read from --description-file "
+                             "if omitted)")
+    parser.add_argument("--description-file", type=Path, default=None,
+                        help="alternative to --description: read from a text file")
+    parser.add_argument("--output", type=Path, required=True,
+                        help="manifest YAML output path")
+    parser.add_argument("--library-root", type=Path,
+                        default=Path.home() / "sci-illustration-library",
+                        help="library root containing library/index.json")
+    parser.add_argument("--llm-mode", choices=["mock", "live"], default="mock",
+                        help="`mock` (default): scaffold a skeleton manifest with TODO notes; "
+                             "`live`: call the configured LLM (not yet wired — see #9)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print the manifest to stdout instead of writing the file")
+    args = parser.parse_args()
+
+    # Resolve description.
+    if args.description:
+        description = args.description
+    elif args.description_file:
+        if not args.description_file.exists():
+            print(f"Error: description file not found: {args.description_file}", file=sys.stderr)
+            return 1
+        description = args.description_file.read_text()
+    else:
+        print("Error: pass --description or --description-file.", file=sys.stderr)
+        return 1
+
+    if not args.template.exists():
+        print(f"Error: template not found: {args.template}", file=sys.stderr)
+        return 1
+
+    placeholders, labels = parse_template(args.template)
+    print(f"Template: {args.template.name}")
+    print(f"  placeholders: {len(placeholders)}")
+    print(f"  labels:       {len(labels)}")
+
+    library_root = args.library_root.expanduser().resolve()
+    records = load_library_records(library_root)
+    print(f"Library:  {len(records)} records under {library_root}")
+
+    if args.llm_mode == "live":
+        try:
+            sem_panels, sem_labels = propose_semantics_live(description, placeholders, labels)
+        except NotImplementedError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+    else:
+        sem_panels, sem_labels = propose_semantics_mock(description, placeholders, labels)
+        print("\n[mock] generated TODO scaffold; replace each `# TODO` panel value with a "
+              "real semantics line then re-run with --llm-mode live to auto-resolve.")
+
+    manifest = build_manifest(library_root, placeholders, labels,
+                              sem_panels, sem_labels, records)
+
+    # Coverage report.
+    panel_total = len(manifest["panels"])
+    panel_resolved = sum(1 for v in manifest["panels"].values() if v)
+    print(f"\nResolved {panel_resolved} / {panel_total} placeholders to library ids "
+          f"({(panel_resolved * 100) // max(panel_total, 1)}%).")
+    if panel_resolved < panel_total:
+        unresolved = panel_total - panel_resolved
+        print(f"  {unresolved} placeholder(s) still need attention — see "
+              f"`_auto_fill_notes` in the output manifest.")
+
+    yaml_text = yaml.safe_dump(manifest, allow_unicode=True, sort_keys=False)
+
+    if args.dry_run:
+        print("\n--- dry-run: would write manifest below ---\n")
+        print(yaml_text)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(yaml_text, encoding="utf-8")
+        print(f"\nWrote: {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto_fill_manifest.py
+++ b/scripts/auto_fill_manifest.py
@@ -104,9 +104,12 @@ def parse_template(template_path: Path) -> tuple[list[Placeholder], list[Label]]
     labels: list[Label] = []
     for tag in ("svg:text", "svg:tspan"):
         for elem in root.xpath(f'.//{tag}[@id]', namespaces=SVG_NS):
-            text = (elem.text or "").strip()
+            # Concatenate the entire text subtree (handles
+            # <text id="x"><tspan>Label</tspan></text> which is the common
+            # shape after Inkscape/Affinity export). `elem.text` alone
+            # would return None and we'd drop the label.
+            text = "".join(elem.itertext()).strip()
             if not text:
-                # skip unlabeled <tspan> wrappers
                 continue
             try:
                 x_raw = elem.get("x"); y_raw = elem.get("y")

--- a/scripts/auto_fill_manifest.py
+++ b/scripts/auto_fill_manifest.py
@@ -295,7 +295,15 @@ def main() -> int:
         print(f"Error: template not found: {args.template}", file=sys.stderr)
         return 1
 
-    placeholders, labels = parse_template(args.template)
+    try:
+        placeholders, labels = parse_template(args.template)
+    except (etree.XMLSyntaxError, etree.ParseError, OSError) as exc:
+        # Convert lxml parse failures into a stable CLI error code so
+        # callers (CI gates, downstream pipelines) get a predictable
+        # signal instead of a Python traceback.
+        print(f"Error: failed to parse template SVG {args.template}: {exc}",
+              file=sys.stderr)
+        return 1
     print(f"Template: {args.template.name}")
     print(f"  placeholders: {len(placeholders)}")
     print(f"  labels:       {len(labels)}")

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -377,13 +377,20 @@ def _pick_phylopic_source(
 
 
 def _detect_raster_ext_from_bytes(content: bytes) -> str | None:
-    """Best-effort magic-byte sniff. None if not recognized."""
+    """Best-effort magic-byte sniff. None if not recognized.
+
+    The SVG branch requires `<svg` to actually appear in the first 512
+    bytes rather than just any `<` opener — otherwise a 200-OK HTML
+    error page or some other XML doc would be saved as `.svg`, producing
+    library rows that "parse but never render" (lxml accepts them, but
+    cairosvg / assemble_figure can't do anything with them).
+    """
     if content.startswith(b"\x89PNG\r\n\x1a\n"):
         return "png"
     if content.startswith(b"\xff\xd8\xff"):
         return "jpg"
-    if content.lstrip().startswith(b"<"):
-        # SVG / XML
+    head = content[:512].lstrip().lower()
+    if b"<svg" in head:
         return "svg"
     return None
 

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -319,8 +319,89 @@ def _phylopic_build_id(api_root: str) -> int:
     return 0  # Many endpoints accept build=0 by 302-redirecting to current.
 
 
-def download_phylopic(target_root: Path, max_count: int | None = None) -> list[dict]:
-    """Page through PhyloPic v2 /images and ingest each silhouette."""
+def _pick_phylopic_source(
+    links: dict,
+    *,
+    allow_raster: bool,
+) -> tuple[str | None, str, str]:
+    """Choose the best download source for one PhyloPic item.
+
+    Returns (href, format, ext) or (None, "", "") if nothing usable was found.
+    `format` is "vector" or "raster"; `ext` is the file extension to save with.
+
+    Priority:
+      1. `vectorFile` if its type indicates SVG (always preferred).
+      2. If `allow_raster`, fall back to `rasterFiles` largest entry, then
+         `sourceFile` if its type is image/png|jpeg. Skip silently otherwise.
+    """
+    vf = links.get("vectorFile") or {}
+    vf_href = vf.get("href")
+    vf_type = (vf.get("type") or "").lower()
+    if vf_href and "svg" in vf_type:
+        return vf_href, "vector", "svg"
+
+    if not allow_raster:
+        return None, "", ""
+
+    # rasterFiles is a list; pick the largest by parsing the "WxH" sizes label.
+    rasters = links.get("rasterFiles") or []
+    best = None
+    best_pixels = -1
+    for r in rasters:
+        sizes = r.get("sizes") or ""  # e.g. "1024x768"
+        try:
+            w_str, h_str = sizes.lower().split("x", 1)
+            pixels = int(w_str) * int(h_str)
+        except (ValueError, AttributeError):
+            pixels = 0
+        if pixels > best_pixels and r.get("href"):
+            best = r
+            best_pixels = pixels
+    if best:
+        ext = "jpg" if "jpeg" in (best.get("type") or "").lower() else "png"
+        return best["href"], "raster", ext
+
+    # sourceFile last — only accept it when we can identify the type.
+    sf = links.get("sourceFile") or {}
+    sf_href = sf.get("href")
+    sf_type = (sf.get("type") or "").lower()
+    if sf_href:
+        if "png" in sf_type:
+            return sf_href, "raster", "png"
+        if "jpeg" in sf_type or "jpg" in sf_type:
+            return sf_href, "raster", "jpg"
+        if "svg" in sf_type:
+            return sf_href, "vector", "svg"
+
+    return None, "", ""
+
+
+def _detect_raster_ext_from_bytes(content: bytes) -> str | None:
+    """Best-effort magic-byte sniff. None if not recognized."""
+    if content.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if content.startswith(b"\xff\xd8\xff"):
+        return "jpg"
+    if content.lstrip().startswith(b"<"):
+        # SVG / XML
+        return "svg"
+    return None
+
+
+def download_phylopic(
+    target_root: Path,
+    max_count: int | None = None,
+    *,
+    allow_raster: bool = False,
+) -> list[dict]:
+    """Page through PhyloPic v2 /images and ingest each silhouette.
+
+    By default vector-only (the library is SVG-first). When `allow_raster`
+    is True, items lacking an SVG vectorFile fall back to the largest
+    rasterFiles entry (then sourceFile), saved with the correct extension
+    based on Content-Type + magic-byte sniff. Each record carries a
+    `format: "vector" | "raster"` field so downstream tools can branch.
+    """
     print("\n[2/6] Downloading PhyloPic (CC0/CC-BY)...")
     src_meta = SOURCES_META["phylopic"]
     api = src_meta["api"]
@@ -387,15 +468,8 @@ def download_phylopic(target_root: Path, max_count: int | None = None) -> list[d
             seen_ids.add(uuid)
 
             links = item.get("_links") or {}
-            # Only ingest from `vectorFile`. `sourceFile` may be a raster
-            # (PNG/JPEG) which would silently corrupt downstream tooling
-            # (etree.parse, cairosvg) when saved with a `.svg` extension.
-            # The library is SVG-only by design; raster fallbacks belong in
-            # a separate ingestion path.
-            vf = links.get("vectorFile") or {}
-            href = vf.get("href")
-            vf_type = (vf.get("type") or "").lower()
-            if not href or "svg" not in vf_type:
+            href, fmt, ext = _pick_phylopic_source(links, allow_raster=allow_raster)
+            if not href:
                 continue
 
             specific_node = links.get("specificNode") or {}
@@ -418,9 +492,17 @@ def download_phylopic(target_root: Path, max_count: int | None = None) -> list[d
                 file_resp = requests.get(href, timeout=20)
                 if file_resp.status_code != 200:
                     continue
-                target_path = target_subdir / f"phylopic-{uuid_short}-{slugify(name)}.svg"
+                # Sanity-check the actual bytes match the chosen extension —
+                # a sourceFile mis-typed as PNG that's actually SVG (or vice
+                # versa) could otherwise corrupt the on-disk format. Magic
+                # sniff overrides the planned ext if the two disagree.
+                sniffed = _detect_raster_ext_from_bytes(file_resp.content[:64])
+                if sniffed and sniffed != ext:
+                    ext = sniffed
+                    fmt = "vector" if sniffed == "svg" else "raster"
+                target_path = target_subdir / f"phylopic-{uuid_short}-{slugify(name)}.{ext}"
                 target_path.write_bytes(file_resp.content)
-            except Exception:
+            except (OSError, requests.exceptions.RequestException):
                 continue
 
             rec = make_record(
@@ -429,7 +511,10 @@ def download_phylopic(target_root: Path, max_count: int | None = None) -> list[d
                 license_override=license_short,
                 attribution_override=attribution,
             )
-            records.append(rec)
+            # Tag the record so downstream tools can branch on raster vs
+            # vector (e.g. assemble_figure.py uses <image> for raster, the
+            # SVG-merge path for vector).
+            rec["format"] = fmt
             pbar.update(1)
             time.sleep(0.05)  # be polite
 
@@ -782,6 +867,15 @@ def build_parser() -> argparse.ArgumentParser:
                         help="NIH BioArt ZIP path (only with --source nih_bioart)")
     parser.add_argument("--summary-only", action="store_true",
                         help="Print library stats without downloading")
+    parser.add_argument(
+        "--phylopic-allow-raster", action="store_true",
+        help=("PhyloPic only: when an item lacks an SVG vectorFile, fall back "
+              "to the largest rasterFiles entry (or sourceFile). Off by default — "
+              "the library is SVG-first and downstream tools (cairosvg, "
+              "assemble_figure SVG-merge) only support SVG. With this flag, "
+              "raster items are saved with the correct extension and tagged "
+              "format=raster so downstream tools can branch."),
+    )
     return parser
 
 
@@ -821,7 +915,10 @@ def main() -> int:
             if s == "bioicons":
                 new = download_bioicons(target_root)
             elif s == "phylopic":
-                new = download_phylopic(target_root, args.max_per_source)
+                new = download_phylopic(
+                    target_root, args.max_per_source,
+                    allow_raster=args.phylopic_allow_raster,
+                )
             elif s == "nih_bioart":
                 if not args.zip:
                     print("\n[3/6] NIH BioArt requires --zip <path> (site is a SPA, no scrape).")

--- a/scripts/download_cc0_seed.py
+++ b/scripts/download_cc0_seed.py
@@ -515,6 +515,7 @@ def download_phylopic(
             # vector (e.g. assemble_figure.py uses <image> for raster, the
             # SVG-merge path for vector).
             rec["format"] = fmt
+            records.append(rec)
             pbar.update(1)
             time.sleep(0.05)  # be polite
 

--- a/scripts/library_build_static.py
+++ b/scripts/library_build_static.py
@@ -297,9 +297,14 @@ def main() -> int:
     rendered = sum(1 for r in catalog if r["thumb"])
     print(f"  rendered {rendered} thumbnails ({len(catalog) - rendered} missing/failed)")
 
+    # `json.dumps` does NOT escape `</`, so a `</script>` substring in any
+    # `name` / `tag` / etc. would prematurely close the inlined script tag
+    # and leave a local HTML-injection surface. Escape `</` -> `<\/` per
+    # the OWASP JSON-in-HTML guidance.
+    catalog_json = json.dumps(catalog, ensure_ascii=False).replace("</", "<\\/")
     html = _HTML_TEMPLATE.format(
         n=len(catalog), cell=args.cell_size,
-        catalog_json=json.dumps(catalog, ensure_ascii=False),
+        catalog_json=catalog_json,
     )
     out_html = output_dir / "index.html"
     out_html.write_text(html, encoding="utf-8")

--- a/scripts/library_build_static.py
+++ b/scripts/library_build_static.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+library_build_static.py — generate a self-contained HTML site for the library.
+
+Sister of `library_tools.py preview --html` (which is per-search). This
+script is the **catalog** view: walk the whole `library/index.json`, render
+a thumbnail per element, and emit a static HTML page with client-side JS
+filters (source / category / license / attribution) plus a full-text search
+box. Open the resulting `index.html` directly in a browser — no server,
+no deploy.
+
+Usage:
+  python scripts/library_build_static.py \
+      --library-root ~/sci-illustration-library \
+      --output ~/sci-illustration-library/_browse
+  open ~/sci-illustration-library/_browse/index.html
+
+By default the catalog is built into `<library_root>/_browse/`. Thumbnails
+are written into `<output>/thumbs/<id>.png` so the HTML stays small (one
+file per element instead of huge data-URIs everywhere). Pass
+`--inline-thumbs` to fall back to data-URIs for true single-file output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import html as html_lib
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+
+try:
+    import cairosvg
+    HAS_CAIROSVG = True
+except (ImportError, OSError):
+    HAS_CAIROSVG = False
+
+try:
+    from PIL import Image
+    HAS_PILLOW = True
+except (ImportError, OSError):
+    HAS_PILLOW = False
+
+
+def _render_thumb_bytes(svg_path: Path, cell: int) -> bytes | None:
+    """Render `svg_path` to a PNG byte string of size `cell`×`cell`. None on failure."""
+    ext = svg_path.suffix.lower()
+    try:
+        if ext == ".svg":
+            if not HAS_CAIROSVG:
+                return None
+            return cairosvg.svg2png(
+                url=str(svg_path), output_width=cell, output_height=cell,
+            )
+        if ext in (".png", ".jpg", ".jpeg"):
+            if not HAS_PILLOW:
+                return None
+            img = Image.open(svg_path).convert("RGB")
+            img.thumbnail((cell, cell))
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _build_catalog_records(records: list[dict], library_root: Path,
+                           output_dir: Path, *,
+                           cell: int, inline_thumbs: bool) -> list[dict]:
+    """Render thumbnails + emit a serializable record list for the JS catalog."""
+    thumbs_dir = output_dir / "thumbs"
+    if not inline_thumbs:
+        thumbs_dir.mkdir(parents=True, exist_ok=True)
+
+    catalog: list[dict] = []
+    for r in records:
+        # Resolve path the same way assemble_figure / library_tools do.
+        root = r.get("_root", library_root / "library")
+        svg_path = Path(root) / r.get("file", "")
+        download_uri = svg_path.resolve().as_uri() if svg_path.exists() else ""
+
+        thumb_data = _render_thumb_bytes(svg_path, cell) if svg_path.exists() else None
+        if inline_thumbs and thumb_data:
+            thumb_uri = "data:image/png;base64," + base64.b64encode(thumb_data).decode()
+        elif thumb_data:
+            thumb_path = thumbs_dir / f"{_safe_id(r['id'])}.png"
+            thumb_path.write_bytes(thumb_data)
+            thumb_uri = f"thumbs/{thumb_path.name}"
+        else:
+            thumb_uri = ""
+
+        catalog.append({
+            "id":       r.get("id", ""),
+            "name":     r.get("name", ""),
+            "category": r.get("category", "") or "uncategorized",
+            "source":   r.get("source", "") or "?",
+            "license":  r.get("license", "") or "?",
+            "attr_required": bool(r.get("attribution_required")),
+            "tags":     r.get("tags", []),
+            "thumb":    thumb_uri,
+            "download": download_uri,
+        })
+    return catalog
+
+
+def _safe_id(s: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in s)
+
+
+# Inlined HTML template (single file so the script ships as one .py).
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>CC0 Library Catalog · {n} elements</title>
+<style>
+  :root {{
+    --fg: #222; --muted: #666; --bg: #fafafa; --card: #fff;
+    --accent: #2E7CD6; --attr: #C8A431; --warn: #A32D2D;
+    --border: #e0e0e0;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+          margin: 0; padding: 1.5rem; background: var(--bg); color: var(--fg); }}
+  header {{ position: sticky; top: 0; z-index: 10; background: var(--bg);
+            padding: 0.75rem 0; border-bottom: 1px solid var(--border); }}
+  h1 {{ font-size: 1.1rem; font-weight: 600; margin: 0 0 0.5rem; color: var(--muted); }}
+  .filters {{ display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }}
+  .filters input, .filters select {{
+    padding: 6px 10px; border: 1px solid var(--border); border-radius: 4px;
+    background: white; font-size: 0.85rem; }}
+  .filters input[type=search] {{ flex: 1 1 280px; min-width: 240px; }}
+  .filters .count {{ color: var(--muted); font-size: 0.85rem; margin-left: auto; }}
+  .grid {{ display: grid;
+           grid-template-columns: repeat(auto-fill, minmax({cell}px, 1fr));
+           gap: 12px; padding-top: 1rem; }}
+  .cell {{ background: var(--card); border: 1px solid var(--border);
+           border-radius: 6px; padding: 8px; transition: box-shadow .15s ease; }}
+  .cell:hover {{ box-shadow: 0 2px 12px rgba(0,0,0,0.08); border-color: #888; }}
+  .cell a {{ display: block; text-decoration: none; color: inherit; }}
+  .cell img {{ display: block; width: 100%; height: {cell}px; object-fit: contain; background: white; }}
+  .cell .missing {{ height: {cell}px; display: flex; align-items: center; justify-content: center;
+                    background: #fff7f3; color: var(--warn); font-size: 0.75rem;
+                    border: 1px dashed #d4796b; }}
+  .name {{ font-weight: 600; font-size: 0.78rem; margin-top: 6px; word-break: break-word; }}
+  .meta {{ color: var(--muted); font-size: 0.65rem; }}
+  .id   {{ color: #999; font-size: 0.6rem; font-family: ui-monospace, monospace; word-break: break-all; }}
+  .attr {{ color: var(--attr); font-weight: 700; }}
+  .empty {{ padding: 3rem; text-align: center; color: var(--muted); }}
+</style>
+</head>
+<body>
+<header>
+  <h1>CC0 Library Catalog · click any thumbnail to download the source file</h1>
+  <div class="filters">
+    <input type="search" id="q" placeholder="search name / category / id / tags…" autofocus>
+    <select id="f-source"><option value="">all sources</option></select>
+    <select id="f-category"><option value="">all categories</option></select>
+    <select id="f-license"><option value="">all licenses</option></select>
+    <label><input type="checkbox" id="f-attr"> CC-BY only</label>
+    <span class="count" id="count">0 / 0</span>
+  </div>
+</header>
+
+<div id="grid" class="grid"></div>
+<div id="empty" class="empty" hidden>no matches</div>
+
+<script>
+const CATALOG = {catalog_json};
+
+const grid = document.getElementById("grid");
+const empty = document.getElementById("empty");
+const count = document.getElementById("count");
+const qInput = document.getElementById("q");
+const fSrc = document.getElementById("f-source");
+const fCat = document.getElementById("f-category");
+const fLic = document.getElementById("f-license");
+const fAttr = document.getElementById("f-attr");
+
+function uniq(values) {{ return [...new Set(values)].sort(); }}
+function fillSelect(el, values) {{
+  for (const v of values) {{
+    const o = document.createElement("option");
+    o.value = v; o.textContent = v;
+    el.appendChild(o);
+  }}
+}}
+fillSelect(fSrc, uniq(CATALOG.map(r => r.source)));
+fillSelect(fCat, uniq(CATALOG.map(r => r.category)));
+fillSelect(fLic, uniq(CATALOG.map(r => r.license)));
+
+function escapeHtml(s) {{
+  return String(s ?? "").replace(/[&<>"']/g,
+    c => ({{"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}})[c]);
+}}
+
+function renderCell(r) {{
+  const thumb = r.thumb
+    ? `<img src="${{escapeHtml(r.thumb)}}" alt="${{escapeHtml(r.name)}}">`
+    : `<div class="missing">missing</div>`;
+  const download = r.download
+    ? `<a href="${{escapeHtml(r.download)}}" download>${{thumb}}</a>`
+    : thumb;
+  const attrBadge = r.attr_required ? ' <span class="attr">[ATTR]</span>' : '';
+  return `<figure class="cell">
+    ${{download}}
+    <figcaption>
+      <div class="name">${{escapeHtml(r.name)}}</div>
+      <div class="meta">${{escapeHtml(r.source)}} · ${{escapeHtml(r.license)}}${{attrBadge}}</div>
+      <div class="meta">${{escapeHtml(r.category)}}</div>
+      <div class="id">${{escapeHtml(r.id)}}</div>
+    </figcaption>
+  </figure>`;
+}}
+
+function refresh() {{
+  const q = qInput.value.trim().toLowerCase();
+  const src = fSrc.value;
+  const cat = fCat.value;
+  const lic = fLic.value;
+  const attr = fAttr.checked;
+
+  const filtered = CATALOG.filter(r => {{
+    if (src && r.source !== src) return false;
+    if (cat && r.category !== cat) return false;
+    if (lic && r.license !== lic) return false;
+    if (attr && !r.attr_required) return false;
+    if (q) {{
+      const hay = (r.name + " " + r.category + " " + r.id + " " + (r.tags || []).join(" ")).toLowerCase();
+      if (!hay.includes(q)) return false;
+    }}
+    return true;
+  }});
+
+  grid.innerHTML = filtered.slice(0, 2000).map(renderCell).join("");
+  empty.hidden = filtered.length > 0;
+  count.textContent = `${{filtered.length}} / ${{CATALOG.length}}`;
+  if (filtered.length > 2000) {{
+    count.textContent += ` (showing first 2000)`;
+  }}
+}}
+[qInput, fSrc, fCat, fLic, fAttr].forEach(el => el.addEventListener("input", refresh));
+refresh();
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a self-contained HTML catalog for the CC0 library "
+                    "(global browse + filter + search).",
+    )
+    parser.add_argument("--library-root", type=Path,
+                        default=Path.home() / "sci-illustration-library",
+                        help="library root containing library/index.json")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="output dir (default: <library-root>/_browse)")
+    parser.add_argument("--cell-size", type=int, default=140,
+                        help="thumbnail edge px (default: 140)")
+    parser.add_argument("--inline-thumbs", action="store_true",
+                        help="embed thumbnails as base64 data-URIs in the HTML "
+                             "instead of writing thumbs/*.png — produces one "
+                             "self-contained but larger HTML file")
+    args = parser.parse_args()
+
+    library_root = args.library_root.expanduser().resolve()
+    output_dir = (
+        args.output.expanduser().resolve()
+        if args.output
+        else library_root / "_browse"
+    )
+    index_path = library_root / "library" / "index.json"
+
+    if not index_path.exists():
+        print(f"Error: {index_path} not found.", file=sys.stderr)
+        print("Run scripts/download_cc0_seed.py first to seed the library.",
+              file=sys.stderr)
+        return 1
+
+    try:
+        records = json.loads(index_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error: failed to read {index_path}: {exc}", file=sys.stderr)
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Building catalog from {len(records)} elements...")
+    catalog = _build_catalog_records(
+        records, library_root, output_dir,
+        cell=args.cell_size, inline_thumbs=args.inline_thumbs,
+    )
+    rendered = sum(1 for r in catalog if r["thumb"])
+    print(f"  rendered {rendered} thumbnails ({len(catalog) - rendered} missing/failed)")
+
+    html = _HTML_TEMPLATE.format(
+        n=len(catalog), cell=args.cell_size,
+        catalog_json=json.dumps(catalog, ensure_ascii=False),
+    )
+    out_html = output_dir / "index.html"
+    out_html.write_text(html, encoding="utf-8")
+    print(f"\nDone. Open: {out_html}")
+    print(f"  or: file://{out_html}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -587,8 +587,140 @@ def _filter_for_grid(args: argparse.Namespace, records: list[dict]) -> list[dict
     return matches[: args.max]
 
 
+def _thumb_data_uri(svg_path: Path, cell: int) -> tuple[str | None, str | None]:
+    """Return (data_uri, error_label) for a single asset thumbnail.
+
+    `data_uri` is a `data:image/...;base64,...` string ready to drop into
+    an `<img src=>`; None when rendering failed and the caller should
+    show `error_label` instead.
+    """
+    import base64
+    ext = svg_path.suffix.lower()
+    try:
+        if ext == ".svg":
+            if not HAS_CAIROSVG:
+                return None, "cairosvg missing"
+            png_bytes = cairosvg.svg2png(
+                url=str(svg_path),
+                output_width=cell,
+                output_height=cell,
+            )
+            return f"data:image/png;base64,{base64.b64encode(png_bytes).decode()}", None
+        if ext in (".png", ".jpg", ".jpeg"):
+            img = Image.open(svg_path).convert("RGB")
+            img.thumbnail((cell, cell))
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}", None
+        return None, f"unsupported {ext}"
+    except _RENDER_EXCEPTIONS as exc:
+        return None, f"render fail: {type(exc).__name__}"
+
+
+def _render_html_grid(
+    matches: list[dict],
+    *,
+    cell: int,
+    cols: int,
+    out_path: Path,
+) -> None:
+    """Write a self-contained interactive HTML thumbnail grid.
+
+    Each cell is `<a href="file://…asset" download>` so clicking initiates a
+    download in any browser. Thumbnails are embedded as base64 data-URIs so
+    the HTML file is portable (no dependent thumbnail directory).
+    """
+    import html as _html_lib
+
+    cells_html: list[str] = []
+    for r in matches:
+        svg_path = resolve_svg_path(r)
+        if not svg_path.exists():
+            thumb_html = (
+                f'<div class="missing" style="width:{cell}px;height:{cell}px;">'
+                f'missing</div>'
+            )
+        else:
+            data_uri, err = _thumb_data_uri(svg_path, cell)
+            if data_uri:
+                thumb_html = (
+                    f'<img src="{data_uri}" alt="{_html_lib.escape(r.get("name",""))}" '
+                    f'width="{cell}" height="{cell}">'
+                )
+            else:
+                thumb_html = (
+                    f'<div class="error" style="width:{cell}px;height:{cell}px;">'
+                    f'{_html_lib.escape(err or "render fail")}</div>'
+                )
+
+        # download link points at the actual on-disk path so clicking initiates
+        # a download in the browser. We use file:// rather than relative path so
+        # the HTML works regardless of where it's saved.
+        download_url = svg_path.resolve().as_uri()
+        attr_flag = (
+            ' <span class="attr">[ATTR]</span>'
+            if r.get("attribution_required") else ""
+        )
+        cells_html.append(
+            f'<figure class="cell">'
+            f'  <a href="{_html_lib.escape(download_url)}" download>'
+            f'    {thumb_html}'
+            f'  </a>'
+            f'  <figcaption>'
+            f'    <span class="name">{_html_lib.escape(r.get("name",""))}</span>'
+            f'    <span class="meta">{_html_lib.escape(r.get("source",""))} '
+            f'| {_html_lib.escape((r.get("license") or "")[:14])}{attr_flag}</span>'
+            f'    <span class="id">{_html_lib.escape(r["id"])}</span>'
+            f'  </figcaption>'
+            f'</figure>'
+        )
+
+    html_doc = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>library preview ({len(matches)} elements)</title>
+<style>
+  body {{ font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+          margin: 1.5rem; background: #fafafa; color: #222; }}
+  h1 {{ font-size: 1rem; font-weight: 600; margin: 0 0 1rem; color: #555; }}
+  .grid {{ display: grid;
+           grid-template-columns: repeat({cols}, 1fr);
+           gap: 14px; }}
+  .cell {{ margin: 0; padding: 8px; background: white;
+           border: 1px solid #e0e0e0; border-radius: 6px;
+           transition: box-shadow .15s ease; }}
+  .cell:hover {{ box-shadow: 0 2px 10px rgba(0,0,0,0.08); border-color: #888; }}
+  .cell a {{ display: block; text-decoration: none; }}
+  .cell img {{ display: block; margin: 0 auto; background: #fff;
+               cursor: pointer; }}
+  .cell .missing, .cell .error {{
+    display: flex; align-items: center; justify-content: center;
+    background: #fff7f3; color: #a32d2d; font-size: 0.75rem;
+    border: 1px dashed #d4796b; }}
+  figcaption {{ display: flex; flex-direction: column;
+                font-size: 0.7rem; line-height: 1.3; margin-top: 6px;
+                color: #444; word-break: break-word; }}
+  .name {{ font-weight: 600; color: #222; }}
+  .meta {{ color: #666; font-size: 0.65rem; }}
+  .attr {{ color: #c8a431; font-weight: 700; }}
+  .id   {{ color: #999; font-size: 0.6rem; font-family: ui-monospace, monospace; }}
+</style>
+</head>
+<body>
+<h1>library preview · {len(matches)} elements · click any thumbnail to download the source file</h1>
+<div class="grid">
+{chr(10).join(cells_html)}
+</div>
+</body>
+</html>
+"""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html_doc, encoding="utf-8")
+
+
 def cmd_preview(args: argparse.Namespace) -> int:
-    """Render a thumbnail grid of matched elements as a single PNG."""
+    """Render a thumbnail grid of matched elements as PNG or interactive HTML."""
     if not HAS_PILLOW:
         print("Error: cmd preview requires `Pillow` (always) and `cairosvg` "
               "(when any asset is SVG)", file=sys.stderr)
@@ -598,6 +730,16 @@ def cmd_preview(args: argparse.Namespace) -> int:
     matches = _filter_for_grid(args, load_unified_index())
     if not matches:
         print("No matches to preview.")
+        return 0
+
+    # `--html out.html` mode: produce a self-contained interactive HTML
+    # grid with embedded data-URI thumbnails and click-to-download links.
+    if args.html:
+        out = Path(args.html).expanduser()
+        print(f"Rendering {len(matches)} thumbnails to HTML grid ({args.cols} cols)...")
+        _render_html_grid(matches, cell=args.cell_size, cols=args.cols, out_path=out)
+        print(f"Saved HTML preview: {out}")
+        print(f"Open with: open {out}  (or: file://{out.resolve()})")
         return 0
 
     cell = args.cell_size
@@ -920,7 +1062,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_prev.add_argument("--max", type=int, default=64, help="max elements (default 64 = 8x8)")
     p_prev.add_argument("--cols", type=int, default=8)
     p_prev.add_argument("--cell-size", type=int, default=120, help="thumbnail edge px")
-    p_prev.add_argument("--output", "-o", default="./preview.png")
+    p_prev.add_argument("--output", "-o", default="./preview.png",
+                        help="PNG output path (default mode)")
+    p_prev.add_argument("--html", default=None,
+                        help=("instead of a PNG, write a self-contained interactive "
+                              "HTML grid to this path; clicking a thumbnail downloads "
+                              "the underlying SVG/PNG asset"))
 
     p_export = sub.add_parser("export", help="bundle elements into a PPTX")
     p_export.add_argument("--ids", help="comma-separated IDs")

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -71,6 +71,22 @@ except (ImportError, OSError):
     HAS_PPTX = False
 
 
+# Narrow set of exceptions we expect from per-element render attempts in
+# cmd_preview / cmd_export. Anything else (KeyError, AttributeError, etc.)
+# is a real bug and should propagate up rather than be silently caught.
+#   - OSError              file not found, libcairo missing, broken Pillow IO
+#   - ValueError           cairosvg internal "bad SVG" path
+#   - etree.XMLSyntaxError lxml's strict parse error
+#   - etree.ParseError     cairosvg's downstream parse failure
+# When Pillow is available we also expect UnidentifiedImageError for raster
+# files that aren't valid PNG/JPEG (truncated download, mis-extension, etc.).
+_RENDER_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    OSError, ValueError, etree.XMLSyntaxError, etree.ParseError,
+)
+if HAS_PILLOW:
+    _RENDER_EXCEPTIONS = _RENDER_EXCEPTIONS + (Image.UnidentifiedImageError,)
+
+
 SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
 # Mutated in main() when --library-root is supplied.
 LIBRARY_ROOT = Path.home() / "sci-illustration-library"
@@ -107,7 +123,7 @@ def load_unified_index() -> list[dict]:
                     seen_ids.add(rid)
                     r.setdefault("_root", json_index.parent)
                     records.append(r)
-        except Exception as exc:
+        except (json.JSONDecodeError, OSError) as exc:
             print(f"[warn] failed to parse {json_index}: {exc}", file=sys.stderr)
 
     # 2. Legacy per-category YAML (manually registered elements).
@@ -136,7 +152,7 @@ def load_unified_index() -> list[dict]:
                     "_legacy": True,
                     "_meta": entry,
                 })
-        except Exception as exc:
+        except (yaml.YAMLError, OSError) as exc:
             print(f"[warn] failed to parse {yaml_index}: {exc}", file=sys.stderr)
 
     return records
@@ -158,7 +174,7 @@ def quality_check(svg_path: Path) -> dict:
     try:
         tree = etree.parse(str(svg_path))
         root = tree.getroot()
-    except Exception as exc:
+    except (etree.XMLSyntaxError, etree.ParseError, OSError) as exc:
         return {"pass": False, "error": str(exc)}
 
     paths = root.findall(".//svg:path", SVG_NS)
@@ -629,7 +645,7 @@ def cmd_preview(args: argparse.Namespace) -> int:
             paste_x = x + (cell - img.width) // 2
             paste_y = y + (cell - img.height) // 2
             canvas.paste(img, (paste_x, paste_y))
-        except Exception as exc:
+        except _RENDER_EXCEPTIONS as exc:
             draw.rectangle([x, y, x + cell, y + cell], outline="orange")
             draw.text((x + 4, y + 4),
                       f"render fail: {type(exc).__name__}",
@@ -708,7 +724,7 @@ def cmd_export(args: argparse.Namespace) -> int:
                         write_to=str(picture_path),
                         output_width=1200,
                     )
-                except Exception as exc:
+                except _RENDER_EXCEPTIONS as exc:
                     print(f"  [skip] {r['id']}: SVG render failed "
                           f"({type(exc).__name__}: {exc})",
                           file=sys.stderr)

--- a/scripts/library_tools.py
+++ b/scripts/library_tools.py
@@ -540,6 +540,10 @@ def cmd_stats(args: argparse.Namespace) -> int:
     by_source = Counter(r.get("source", "?") for r in records)
     by_category = Counter(r.get("category", "?") for r in records)
     by_license = Counter(r.get("license", "?") for r in records)
+    # Format defaults to "vector" for legacy rows that pre-date the
+    # PhyloPic raster-fallback path (see #11). Records explicitly tagged
+    # by download_phylopic carry their real "vector" / "raster" value.
+    by_format = Counter(r.get("format", "vector") for r in records)
 
     print(f"\n{'=' * 60}")
     print(f"Library Stats  (root: {LIBRARY_ROOT})")
@@ -557,6 +561,10 @@ def cmd_stats(args: argparse.Namespace) -> int:
     print("\nBy license:")
     for lic, n in by_license.most_common():
         print(f"  {lic:25s} {n:>6d}")
+
+    print("\nBy format (vector vs raster):")
+    for fmt, n in by_format.most_common():
+        print(f"  {fmt:25s} {n:>6d}")
 
     attr_required = sum(1 for r in records if r.get("attribution_required"))
     print(f"\nAttribution required: {attr_required} elements")

--- a/scripts/lowfi_trace.py
+++ b/scripts/lowfi_trace.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+lowfi_trace.py — normalize element style across a multi-source CC0 library.
+
+The bootstrap phase pulls SVGs from heterogeneous sources (BioIcons,
+PhyloPic, Reactome, SciDraw, Servier, Recraft, GPT-Image-2 outline) — each
+with its own line weight, palette, abstraction level. Mixing them
+side-by-side in a 4-panel figure looks like a Frankenstein collage.
+
+This script does the v0.2 "low-fidelity tracing" pass the user proposed
+on 2026-05-03 (issue #2): for each input SVG, normalize:
+
+  - **stroke-width** — every stroke clamped to a single project value
+  - **palette** — every fill/stroke color snapped to the nearest swatch
+    in the project palette
+  - **gradients** — collapsed to flat fills (mid-stop color)
+  - **transforms** — flattened where simple (translate/scale only)
+  - optional: simplify path detail via Inkscape
+
+Output: a parallel `_normalized/` tree with the same relative paths.
+Original elements are left untouched so the operation is repeatable.
+
+Usage:
+  python lowfi_trace.py --library-root ~/sci-illustration-library \
+                        --palette _palettes/nature-flat-blue.yaml \
+                        --stroke-width 1.5
+  # then point assemble_figure.py at <library_root>/library_normalized/
+
+Prefer `--dry-run` first to see how many elements would change without
+touching the disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from lxml import etree
+
+
+SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+SVG_TAG = "{http://www.w3.org/2000/svg}"
+
+# Module-global, set by main() via --library-root. Functions take it as
+# an arg so they can be unit-tested without touching the global.
+DEFAULT_LIBRARY_ROOT = Path.home() / "sci-illustration-library"
+
+
+# ---------------------------------------------------------------------------
+# Palette loading + nearest-color
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Color:
+    r: int
+    g: int
+    b: int
+
+    @classmethod
+    def from_hex(cls, s: str) -> "Color | None":
+        s = s.strip().lstrip("#")
+        if len(s) == 3:
+            s = "".join(c * 2 for c in s)
+        if len(s) != 6:
+            return None
+        try:
+            return cls(int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+        except ValueError:
+            return None
+
+    def to_hex(self) -> str:
+        return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+
+    def distance_sq(self, other: "Color") -> int:
+        return (self.r - other.r) ** 2 + (self.g - other.g) ** 2 + (self.b - other.b) ** 2
+
+
+def load_palette(palette_path: Path | None) -> list[Color]:
+    """Load a palette from YAML; return [] (no snapping) if path is None.
+
+    Schema:
+      colors:
+        - "#1B5BA0"
+        - "#2E7CD6"
+        - ...
+    """
+    if palette_path is None:
+        return []
+    try:
+        data = yaml.safe_load(palette_path.read_text()) or {}
+    except (yaml.YAMLError, OSError) as exc:
+        print(f"[error] failed to load palette {palette_path}: {exc}", file=sys.stderr)
+        return []
+    raw = data.get("colors") or []
+    out: list[Color] = []
+    for item in raw:
+        c = Color.from_hex(str(item))
+        if c is not None:
+            out.append(c)
+    return out
+
+
+def snap_to_palette(value: str, palette: list[Color]) -> str:
+    """Snap a single SVG color value to the nearest palette swatch.
+
+    Pass through `none` / `transparent` / non-color strings (e.g.
+    `url(#grad)`) unchanged. Recognized inputs are 3- and 6-hex.
+    """
+    if not palette:
+        return value
+    s = value.strip().lower()
+    if s in ("none", "transparent", "currentcolor", "inherit") or s.startswith("url"):
+        return value
+    src = Color.from_hex(s)
+    if src is None:
+        return value
+    nearest = min(palette, key=lambda c: src.distance_sq(c))
+    return nearest.to_hex()
+
+
+# ---------------------------------------------------------------------------
+# Element normalization
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Stats:
+    files_seen: int = 0
+    files_normalized: int = 0
+    strokes_clamped: int = 0
+    colors_snapped: int = 0
+    gradients_flattened: int = 0
+
+
+def _flatten_gradient_to_flat_fill(
+    root: etree._Element,
+    gradient_id_to_color: dict[str, str],
+) -> int:
+    """Replace every `url(#gradient-id)` reference with the gradient's mid-stop color."""
+    flattened = 0
+    for elem in root.iter():
+        for attr in ("fill", "stroke"):
+            val = elem.get(attr) or ""
+            if val.startswith("url(#"):
+                gid = val[5:].rstrip(")").strip("\"' ")
+                if gid in gradient_id_to_color:
+                    elem.set(attr, gradient_id_to_color[gid])
+                    flattened += 1
+    return flattened
+
+
+def _gradient_mid_color(grad_elem: etree._Element) -> str | None:
+    """Pick the middle stop's color from a `<linearGradient>` / `<radialGradient>`."""
+    stops = grad_elem.findall(".//svg:stop", SVG_NS)
+    if not stops:
+        return None
+    mid = stops[len(stops) // 2]
+    color = mid.get("stop-color")
+    if color:
+        return color
+    style = mid.get("style") or ""
+    for chunk in style.split(";"):
+        if "stop-color" in chunk:
+            return chunk.split(":", 1)[-1].strip()
+    return None
+
+
+def normalize_one(
+    svg_path: Path,
+    out_path: Path,
+    *,
+    palette: list[Color],
+    stroke_width_pt: float | None,
+    flatten_gradients: bool,
+    stats: Stats,
+) -> bool:
+    """Normalize one SVG; write to `out_path`. Return True iff anything changed."""
+    try:
+        tree = etree.parse(str(svg_path))
+    except (etree.XMLSyntaxError, etree.ParseError, OSError) as exc:
+        print(f"[skip] {svg_path}: {exc}", file=sys.stderr)
+        return False
+    root = tree.getroot()
+    changed = False
+
+    # 1. Flatten gradients first so the subsequent color-snap pass picks up
+    #    the inserted flat-fill values.
+    if flatten_gradients:
+        gradient_ids: dict[str, str] = {}
+        for tag in (f"{SVG_TAG}linearGradient", f"{SVG_TAG}radialGradient"):
+            for grad in root.iter(tag):
+                gid = grad.get("id")
+                if not gid:
+                    continue
+                col = _gradient_mid_color(grad)
+                if col:
+                    gradient_ids[gid] = col
+        if gradient_ids:
+            flat = _flatten_gradient_to_flat_fill(root, gradient_ids)
+            if flat:
+                stats.gradients_flattened += flat
+                changed = True
+
+    # 2. Snap fill / stroke colors to nearest palette entry.
+    if palette:
+        for elem in root.iter():
+            for attr in ("fill", "stroke", "stop-color"):
+                val = elem.get(attr)
+                if val:
+                    new = snap_to_palette(val, palette)
+                    if new != val:
+                        elem.set(attr, new)
+                        stats.colors_snapped += 1
+                        changed = True
+            # also handle `style="fill:#…;stroke:#…"`
+            style = elem.get("style") or ""
+            if style and (":#" in style or "rgb" in style):
+                new_style = _snap_style_colors(style, palette)
+                if new_style != style:
+                    elem.set("style", new_style)
+                    stats.colors_snapped += 1
+                    changed = True
+
+    # 3. Clamp stroke widths.
+    if stroke_width_pt is not None:
+        target = str(stroke_width_pt)
+        for elem in root.iter():
+            sw = elem.get("stroke-width")
+            if sw and sw != target:
+                elem.set("stroke-width", target)
+                stats.strokes_clamped += 1
+                changed = True
+
+    if changed:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        tree.write(str(out_path), xml_declaration=True, encoding="utf-8")
+    return changed
+
+
+def _snap_style_colors(style: str, palette: list[Color]) -> str:
+    """Walk a `style="..."` value and snap each color to the palette."""
+    out_chunks: list[str] = []
+    for chunk in style.split(";"):
+        if ":" in chunk:
+            key, _, val = chunk.partition(":")
+            key_clean = key.strip().lower()
+            if key_clean in ("fill", "stroke", "stop-color"):
+                snapped = snap_to_palette(val.strip(), palette)
+                out_chunks.append(f"{key.strip()}:{snapped}")
+                continue
+        out_chunks.append(chunk)
+    return ";".join(out_chunks)
+
+
+# ---------------------------------------------------------------------------
+# Library walker
+# ---------------------------------------------------------------------------
+
+
+def walk_library(
+    library_root: Path,
+    output_root: Path,
+    *,
+    palette: list[Color],
+    stroke_width_pt: float | None,
+    flatten_gradients: bool,
+    dry_run: bool,
+) -> Stats:
+    """Walk every `library/**/*.svg` and write normalized copies to `output_root`."""
+    stats = Stats()
+    src_dir = library_root / "library"
+    if not src_dir.is_dir():
+        print(f"[error] library directory not found: {src_dir}", file=sys.stderr)
+        return stats
+
+    for svg in src_dir.rglob("*.svg"):
+        stats.files_seen += 1
+        rel = svg.relative_to(src_dir)
+        out = output_root / rel
+        if dry_run:
+            # Render to /dev/null to count what *would* change.
+            tmp = Path("/dev/null") if sys.platform != "win32" else Path("nul")
+            try:
+                changed = normalize_one(
+                    svg, tmp,
+                    palette=palette,
+                    stroke_width_pt=stroke_width_pt,
+                    flatten_gradients=flatten_gradients,
+                    stats=stats,
+                )
+            except OSError:
+                # Can't actually write to /dev/null on some setups; just count
+                # everything as "would normalize".
+                changed = True
+            if changed:
+                stats.files_normalized += 1
+            continue
+        changed = normalize_one(
+            svg, out,
+            palette=palette,
+            stroke_width_pt=stroke_width_pt,
+            flatten_gradients=flatten_gradients,
+            stats=stats,
+        )
+        if changed:
+            stats.files_normalized += 1
+        else:
+            # No-op: copy through so the normalized tree is complete and the
+            # downstream `library_root_normalized` is a 1:1 mirror.
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(svg, out)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Low-fidelity style normalization across the CC0 element library "
+                    "(stroke clamp, palette snap, gradient flatten).",
+    )
+    parser.add_argument("--library-root", type=Path, default=DEFAULT_LIBRARY_ROOT,
+                        help=f"library root (default: {DEFAULT_LIBRARY_ROOT})")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="output root (default: <library-root>/library_normalized)")
+    parser.add_argument("--palette", type=Path, default=None,
+                        help="YAML with `colors:` list of hex strings; passes "
+                             "through colors unchanged when omitted")
+    parser.add_argument("--stroke-width", type=float, default=None,
+                        help="clamp every stroke-width to this value (in viewBox units; "
+                             "rule of thumb 1.0–2.0 for printable figures)")
+    parser.add_argument("--no-flatten-gradients", action="store_true",
+                        help="leave <linearGradient>/<radialGradient> references "
+                             "alone; default flattens them to mid-stop flat fill")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what would change without writing the output tree")
+    args = parser.parse_args()
+
+    library_root = args.library_root.expanduser().resolve()
+    output_root = (
+        args.output.expanduser().resolve()
+        if args.output
+        else library_root / "library_normalized"
+    )
+    palette = load_palette(args.palette.expanduser() if args.palette else None)
+
+    print(f"library:  {library_root / 'library'}")
+    print(f"output:   {output_root}")
+    print(f"palette:  {len(palette)} swatches"
+          f"{' (no snap)' if not palette else ''}")
+    print(f"stroke:   {args.stroke_width}"
+          f"{' (no clamp)' if args.stroke_width is None else ''}")
+    print(f"gradients: {'leave-as-is' if args.no_flatten_gradients else 'flatten'}")
+    print(f"mode:     {'DRY-RUN' if args.dry_run else 'WRITE'}\n")
+
+    stats = walk_library(
+        library_root, output_root,
+        palette=palette,
+        stroke_width_pt=args.stroke_width,
+        flatten_gradients=not args.no_flatten_gradients,
+        dry_run=args.dry_run,
+    )
+
+    print(f"\nWalked:    {stats.files_seen} svg files")
+    print(f"Changed:   {stats.files_normalized}"
+          f" ({stats.files_normalized * 100 // max(stats.files_seen, 1)}%)")
+    print(f"  - colors snapped:    {stats.colors_snapped}")
+    print(f"  - strokes clamped:   {stats.strokes_clamped}")
+    print(f"  - gradients flattened:{stats.gradients_flattened}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lowfi_trace.py
+++ b/scripts/lowfi_trace.py
@@ -96,7 +96,20 @@ def load_palette(palette_path: Path | None) -> list[Color]:
     except (yaml.YAMLError, OSError) as exc:
         print(f"[error] failed to load palette {palette_path}: {exc}", file=sys.stderr)
         return []
-    raw = data.get("colors") or []
+    # Schema validation — without this, a typo like a top-level list
+    # instead of `{colors: [...]}`, or `colors: "#1B5BA0"` (a string
+    # instead of a list), silently yields an empty palette and the user
+    # wonders why nothing got snapped. Surface a clear error instead.
+    if not isinstance(data, dict):
+        print(f"[error] {palette_path}: top-level must be a mapping with a "
+              f"`colors:` list, got {type(data).__name__}", file=sys.stderr)
+        return []
+    raw = data.get("colors")
+    if not isinstance(raw, list):
+        print(f"[error] {palette_path}: `colors:` must be a list of hex "
+              f"strings, got {type(raw).__name__ if raw is not None else 'missing'}",
+              file=sys.stderr)
+        return []
     out: list[Color] = []
     for item in raw:
         c = Color.from_hex(str(item))
@@ -326,8 +339,11 @@ def walk_library(
     stats = Stats()
     src_dir = library_root / "library"
     if not src_dir.is_dir():
+        # Hard fail with a non-zero exit so a misconfigured `--library-root`
+        # in CI / batch is treated as failure rather than "successfully
+        # normalized 0 files". Caller's `main()` propagates the SystemExit.
         print(f"[error] library directory not found: {src_dir}", file=sys.stderr)
-        return stats
+        raise SystemExit(1)
 
     for svg in src_dir.rglob("*.svg"):
         stats.files_seen += 1

--- a/scripts/lowfi_trace.py
+++ b/scripts/lowfi_trace.py
@@ -141,7 +141,13 @@ def _flatten_gradient_to_flat_fill(
     root: etree._Element,
     gradient_id_to_color: dict[str, str],
 ) -> int:
-    """Replace every `url(#gradient-id)` reference with the gradient's mid-stop color."""
+    """Replace every `url(#gradient-id)` reference with the gradient's mid-stop color.
+
+    Walks both the explicit `fill` / `stroke` attributes AND the inline
+    `style="fill:url(#…); stroke:url(#…)"` form that Inkscape/Affinity emit;
+    without the style pass, gradient references baked into `style=` survive
+    the flatten and the downstream palette-snap can't reach them.
+    """
     flattened = 0
     for elem in root.iter():
         for attr in ("fill", "stroke"):
@@ -151,6 +157,25 @@ def _flatten_gradient_to_flat_fill(
                 if gid in gradient_id_to_color:
                     elem.set(attr, gradient_id_to_color[gid])
                     flattened += 1
+        style = elem.get("style") or ""
+        if "url(#" in style:
+            new_chunks: list[str] = []
+            style_changed = False
+            for chunk in style.split(";"):
+                key, sep, val = chunk.partition(":")
+                key_clean = key.strip().lower()
+                val_clean = val.strip()
+                if (key_clean in ("fill", "stroke")
+                        and val_clean.startswith("url(#")):
+                    gid = val_clean[5:].rstrip(")").strip("\"' ")
+                    if gid in gradient_id_to_color:
+                        new_chunks.append(f"{key.strip()}:{gradient_id_to_color[gid]}")
+                        flattened += 1
+                        style_changed = True
+                        continue
+                new_chunks.append(chunk)
+            if style_changed:
+                elem.set("style", ";".join(new_chunks))
     return flattened
 
 
@@ -226,7 +251,9 @@ def normalize_one(
                     stats.colors_snapped += 1
                     changed = True
 
-    # 3. Clamp stroke widths.
+    # 3. Clamp stroke widths. Cover both `stroke-width="..."` attributes
+    #    and inline `style="stroke-width:..."`, since Inkscape/Affinity
+    #    routinely emit the latter.
     if stroke_width_pt is not None:
         target = str(stroke_width_pt)
         for elem in root.iter():
@@ -235,10 +262,34 @@ def normalize_one(
                 elem.set("stroke-width", target)
                 stats.strokes_clamped += 1
                 changed = True
+            style = elem.get("style") or ""
+            if "stroke-width" in style:
+                new_chunks: list[str] = []
+                style_changed = False
+                for chunk in style.split(";"):
+                    key, sep, val = chunk.partition(":")
+                    if (key.strip().lower() == "stroke-width"
+                            and val.strip() != target):
+                        new_chunks.append(f"{key.strip()}:{target}")
+                        style_changed = True
+                        continue
+                    new_chunks.append(chunk)
+                if style_changed:
+                    elem.set("style", ";".join(new_chunks))
+                    stats.strokes_clamped += 1
+                    changed = True
 
     if changed:
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        tree.write(str(out_path), xml_declaration=True, encoding="utf-8")
+        # Tolerate write failures the same way the read path does — one
+        # bad path/permission on a single file shouldn't kill the whole
+        # batch (the caller's `walk_library` continues on a False return).
+        try:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            tree.write(str(out_path), xml_declaration=True, encoding="utf-8")
+        except OSError as exc:
+            print(f"[skip] {svg_path}: failed to write {out_path}: {exc}",
+                  file=sys.stderr)
+            return False
     return changed
 
 
@@ -311,9 +362,14 @@ def walk_library(
             stats.files_normalized += 1
         else:
             # No-op: copy through so the normalized tree is complete and the
-            # downstream `library_root_normalized` is a 1:1 mirror.
-            out.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(svg, out)
+            # downstream `library_root_normalized` is a 1:1 mirror. Tolerate
+            # a single copy failure (permissions / disk full) and continue.
+            try:
+                out.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(svg, out)
+            except OSError as exc:
+                print(f"[skip] {svg}: failed to copy to {out}: {exc}",
+                      file=sys.stderr)
     return stats
 
 
@@ -350,6 +406,21 @@ def main() -> int:
         if args.output
         else library_root / "library_normalized"
     )
+    # Refuse to write into <library-root>/library, otherwise rglob() on the
+    # next run would re-pick up our own output and the library would
+    # recursively bloat (or two passes would normalize their own outputs).
+    src_dir = (library_root / "library").resolve()
+    try:
+        output_root.relative_to(src_dir)
+    except ValueError:
+        pass
+    else:
+        print(f"Error: --output ({output_root}) must not be inside the source "
+              f"library directory ({src_dir}); pick a sibling like "
+              f"{library_root / 'library_normalized'} instead.",
+              file=sys.stderr)
+        return 1
+
     palette = load_palette(args.palette.expanduser() if args.palette else None)
 
     print(f"library:  {library_root / 'library'}")

--- a/scripts/style_drift_scan.py
+++ b/scripts/style_drift_scan.py
@@ -191,8 +191,12 @@ def _collect_style_ids(library_root: Path) -> list[str]:
                 sid = r.get("style_id") or (r.get("_meta") or {}).get("style_id")
                 if sid:
                     style_ids.add(sid)
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            # Match the YAML branch's surfacing — silent swallow would
+            # produce a "no drift" false-negative report when the index
+            # was unreadable.
+            print(f"[warn] style_drift_scan: failed to parse {json_index}: {exc}",
+                  file=sys.stderr)
     # Legacy per-category YAMLs definitely have it.
     import yaml  # local import: keeps style_drift_scan importable without yaml on the path
     for category in ("cells", "molecules", "organelles", "tissues",
@@ -333,6 +337,15 @@ def main() -> int:
         if args.references_dir
         else library_root / "_style-references"
     )
+
+    # Range check: 8x8 average-hash is 64 bits, so a threshold outside
+    # [0, 64] is meaningless. Negative values would flip the gate to
+    # "everything drifts", >64 to "nothing drifts" — both are likely
+    # typos rather than intentional.
+    if not 0 <= args.threshold_bits <= 64:
+        print(f"Error: --threshold-bits must be in [0, 64], got {args.threshold_bits}",
+              file=sys.stderr)
+        return 1
 
     if not references_dir.is_dir():
         print(f"Error: references dir not found: {references_dir}", file=sys.stderr)

--- a/scripts/style_drift_scan.py
+++ b/scripts/style_drift_scan.py
@@ -194,19 +194,24 @@ def _collect_style_ids(library_root: Path) -> list[str]:
         except (json.JSONDecodeError, OSError):
             pass
     # Legacy per-category YAMLs definitely have it.
+    import yaml  # local import: keeps style_drift_scan importable without yaml on the path
     for category in ("cells", "molecules", "organelles", "tissues",
                      "organs", "equipment", "pathways", "arrows"):
         yp = library_root / category / "_index.yaml"
         if not yp.exists():
             continue
         try:
-            import yaml
             data = yaml.safe_load(yp.read_text()) or {}
             for entry in data.get("elements", []):
                 sid = entry.get("style_id")
                 if sid:
                     style_ids.add(sid)
-        except Exception:  # noqa: BLE001
+        except (yaml.YAMLError, OSError, AttributeError, TypeError) as exc:
+            # Narrow set: parse / IO / shape errors. Anything else
+            # (KeyError, MemoryError, …) propagates as a real bug rather
+            # than producing a false-negative "no drift" report.
+            print(f"[warn] style_drift_scan: failed to parse {yp}: {exc}",
+                  file=sys.stderr)
             continue
     return sorted(style_ids)
 

--- a/scripts/style_drift_scan.py
+++ b/scripts/style_drift_scan.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+style_drift_scan.py — periodic style-reference drift check.
+
+Recraft V3 element generation locks visual style via a `style_id` that is
+nominally stable but can drift if Recraft re-trains the underlying style.
+Without periodic verification, the library silently slides away from the
+canonical exemplars under `_style-references/`.
+
+This script:
+  1. Loads every `style_id` actually used in the unified library index.
+  2. For each style_id, runs a known prompt against Recraft to get a
+     fresh sample (or, in `--dry-run` / `--mock-provider`, fakes one).
+  3. Compares the new sample to the canonical
+     `_style-references/<style>.svg` via a perceptual-hash distance
+     (8×8 average-hash, Hamming distance, 0–64).
+  4. Writes a markdown drift report grouped by style_id; flags any
+     style whose drift is above `--threshold-bits` (default 12 bits).
+
+The scan is designed to run weekly via `/schedule`. In CI / dry-run
+mode, no API calls are made and the report comes back saying "0
+drift" — useful as a smoke check that the pipeline is wired correctly
+before exposing the live API key.
+
+Usage:
+  python scripts/style_drift_scan.py --dry-run
+  python scripts/style_drift_scan.py \
+      --library-root ~/sci-illustration-library \
+      --report drift-report.md
+  python scripts/style_drift_scan.py --threshold-bits 8 --auto-update-references
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Callable
+
+try:
+    import cairosvg
+    HAS_CAIROSVG = True
+except (ImportError, OSError):
+    HAS_CAIROSVG = False
+
+try:
+    from PIL import Image
+    HAS_PILLOW = True
+except (ImportError, OSError):
+    HAS_PILLOW = False
+
+
+DEFAULT_LIBRARY_ROOT = Path.home() / "sci-illustration-library"
+
+# A neutral prompt used to probe each style_id. Should be stable across runs
+# so that hash differences attribute to the *style*, not the *content*.
+PROBE_PROMPT = "a single flat-style icon of a hepatocyte, transparent background"
+
+
+# ---------------------------------------------------------------------------
+# pHash (8×8 average-hash) — 64-bit fingerprint
+# ---------------------------------------------------------------------------
+
+
+def _png_to_8x8_grayscale(data: bytes) -> bytes | None:
+    """Resize the PNG bytes to 8×8 grayscale; return raw 64-byte buffer."""
+    if not HAS_PILLOW:
+        return None
+    from io import BytesIO
+    try:
+        img = Image.open(BytesIO(data)).convert("L").resize((8, 8), Image.LANCZOS)
+        return img.tobytes()
+    except (OSError, ValueError):
+        return None
+
+
+def average_hash(buf: bytes) -> int:
+    """Classic average-hash: 1 if pixel ≥ mean, else 0. 64 bits packed into an int."""
+    if not buf or len(buf) != 64:
+        return 0
+    mean = sum(buf) / 64
+    bits = 0
+    for i, px in enumerate(buf):
+        if px >= mean:
+            bits |= 1 << (63 - i)
+    return bits
+
+
+def hamming_distance(a: int, b: int) -> int:
+    return bin(a ^ b).count("1")
+
+
+def hash_svg(svg_path: Path) -> int | None:
+    """Render SVG → 8×8 grayscale → average-hash. None on failure."""
+    if not HAS_CAIROSVG or not HAS_PILLOW:
+        return None
+    try:
+        png = cairosvg.svg2png(url=str(svg_path), output_width=64, output_height=64)
+    except (OSError, ValueError):
+        return None
+    buf = _png_to_8x8_grayscale(png)
+    return average_hash(buf) if buf else None
+
+
+# ---------------------------------------------------------------------------
+# Provider abstraction (Recraft live vs mock)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockProvider:
+    """A no-op provider that 'regenerates' by returning the existing reference.
+
+    Distance is 0; useful for `--dry-run` and as a wiring smoke test.
+    """
+    references_dir: Path
+
+    def regenerate(self, style_id: str, prompt: str) -> Path | None:
+        candidate = self.references_dir / f"{style_id}.svg"
+        return candidate if candidate.exists() else None
+
+
+@dataclass
+class _RecraftProvider:
+    """Live Recraft v3 provider. Implementation deferred until BioRender-MCP
+    pattern is finalized — see issue #3 / hint in README. For now this raises
+    if invoked, so the user has to pass `--mock-provider` explicitly until
+    the live wiring lands. The wiring is intentionally a separate ticket so
+    the drift-scan plumbing can ship and be tested today.
+    """
+    api_key: str
+    references_dir: Path
+
+    def regenerate(self, style_id: str, prompt: str) -> Path | None:
+        raise NotImplementedError(
+            "Live Recraft regeneration is not yet wired up. Pass "
+            "`--mock-provider` to use the in-place exemplar as the 'fresh' "
+            "sample (smoke-test only), or implement the call inside "
+            "_RecraftProvider.regenerate() and remove this exception."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Drift scan
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StyleResult:
+    style_id: str
+    reference_path: Path
+    sample_path: Path | None = None
+    distance_bits: int | None = None
+    error: str | None = None
+
+
+@dataclass
+class ScanReport:
+    started: str
+    threshold_bits: int
+    results: list[StyleResult] = field(default_factory=list)
+
+    def by_severity(self) -> tuple[list[StyleResult], list[StyleResult], list[StyleResult]]:
+        """Return (drifted, ok, errored) buckets."""
+        drifted: list[StyleResult] = []
+        ok: list[StyleResult] = []
+        errored: list[StyleResult] = []
+        for r in self.results:
+            if r.error is not None:
+                errored.append(r)
+            elif r.distance_bits is not None and r.distance_bits >= self.threshold_bits:
+                drifted.append(r)
+            else:
+                ok.append(r)
+        return drifted, ok, errored
+
+
+def _collect_style_ids(library_root: Path) -> list[str]:
+    """Return distinct `style_id` values registered in the library."""
+    style_ids: set[str] = set()
+    # CC0 bulk index might carry a `style_id` field if a future register
+    # tier writes it; tolerate missing.
+    json_index = library_root / "library" / "index.json"
+    if json_index.exists():
+        try:
+            for r in json.loads(json_index.read_text()):
+                sid = r.get("style_id") or (r.get("_meta") or {}).get("style_id")
+                if sid:
+                    style_ids.add(sid)
+        except (json.JSONDecodeError, OSError):
+            pass
+    # Legacy per-category YAMLs definitely have it.
+    for category in ("cells", "molecules", "organelles", "tissues",
+                     "organs", "equipment", "pathways", "arrows"):
+        yp = library_root / category / "_index.yaml"
+        if not yp.exists():
+            continue
+        try:
+            import yaml
+            data = yaml.safe_load(yp.read_text()) or {}
+            for entry in data.get("elements", []):
+                sid = entry.get("style_id")
+                if sid:
+                    style_ids.add(sid)
+        except Exception:  # noqa: BLE001
+            continue
+    return sorted(style_ids)
+
+
+def scan(
+    library_root: Path,
+    *,
+    threshold_bits: int,
+    regenerate: Callable[[str, str], Path | None],
+    references_dir: Path,
+) -> ScanReport:
+    report = ScanReport(started=date.today().isoformat(), threshold_bits=threshold_bits)
+    style_ids = _collect_style_ids(library_root)
+    if not style_ids:
+        return report
+
+    for sid in style_ids:
+        ref_path = references_dir / f"{sid}.svg"
+        result = StyleResult(style_id=sid, reference_path=ref_path)
+
+        if not ref_path.exists():
+            result.error = f"reference SVG not found: {ref_path}"
+            report.results.append(result)
+            continue
+
+        try:
+            sample_path = regenerate(sid, PROBE_PROMPT)
+        except NotImplementedError as exc:
+            result.error = f"provider error: {exc}"
+            report.results.append(result)
+            continue
+
+        if sample_path is None or not sample_path.exists():
+            result.error = "regenerate() returned no sample"
+            report.results.append(result)
+            continue
+
+        result.sample_path = sample_path
+        ref_hash = hash_svg(ref_path)
+        sample_hash = hash_svg(sample_path)
+        if ref_hash is None or sample_hash is None:
+            result.error = "could not hash reference and/or sample (cairosvg/Pillow missing?)"
+            report.results.append(result)
+            continue
+
+        result.distance_bits = hamming_distance(ref_hash, sample_hash)
+        report.results.append(result)
+    return report
+
+
+def render_markdown(report: ScanReport) -> str:
+    drifted, ok, errored = report.by_severity()
+    lines: list[str] = [
+        "# Style drift scan",
+        f"_Generated {report.started} · threshold = {report.threshold_bits} bits / 64_",
+        "",
+        f"- Drifted (≥ threshold): **{len(drifted)}**",
+        f"- OK:                    {len(ok)}",
+        f"- Errored:               {len(errored)}",
+        "",
+    ]
+    if drifted:
+        lines.append("## Drift over threshold")
+        lines.append("")
+        for r in drifted:
+            lines.append(f"- `{r.style_id}` — distance **{r.distance_bits}** / 64")
+        lines.append("")
+    if ok:
+        lines.append("## Stable")
+        lines.append("")
+        for r in ok:
+            lines.append(f"- `{r.style_id}` — distance {r.distance_bits} / 64")
+        lines.append("")
+    if errored:
+        lines.append("## Errored (no judgement issued)")
+        lines.append("")
+        for r in errored:
+            lines.append(f"- `{r.style_id}` — {r.error}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect Recraft style drift against the canonical exemplars "
+                    "in `_style-references/`.",
+    )
+    parser.add_argument("--library-root", type=Path, default=DEFAULT_LIBRARY_ROOT,
+                        help=f"library root (default: {DEFAULT_LIBRARY_ROOT})")
+    parser.add_argument("--references-dir", type=Path, default=None,
+                        help="dir containing <style_id>.svg exemplars "
+                             "(default: <library-root>/_style-references)")
+    parser.add_argument("--threshold-bits", type=int, default=12,
+                        help="Hamming distance (out of 64) above which to flag "
+                             "drift (default: 12 bits ≈ 18.75%)")
+    parser.add_argument("--report", type=Path, default=None,
+                        help="markdown report output path (default: stdout)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="don't call Recraft; treat the existing exemplar "
+                             "as the regenerated sample (distance always 0). "
+                             "Use this to verify wiring without burning API credit.")
+    parser.add_argument("--mock-provider", action="store_true",
+                        help="alias for --dry-run; explicit when a CI uses no API key")
+    parser.add_argument("--auto-update-references", action="store_true",
+                        help="(future) replace `_style-references/<id>.svg` with the "
+                             "regenerated sample when distance < threshold; bumps the "
+                             "exemplar to track 'real' Recraft updates. NOOP today "
+                             "since the live provider isn't wired.")
+    args = parser.parse_args()
+
+    library_root = args.library_root.expanduser().resolve()
+    references_dir = (
+        args.references_dir.expanduser().resolve()
+        if args.references_dir
+        else library_root / "_style-references"
+    )
+
+    if not references_dir.is_dir():
+        print(f"Error: references dir not found: {references_dir}", file=sys.stderr)
+        print("Create it and add <style_id>.svg files first.", file=sys.stderr)
+        return 1
+
+    if args.dry_run or args.mock_provider:
+        provider = _MockProvider(references_dir=references_dir)
+    else:
+        api_key = os.environ.get("RECRAFT_API_KEY")
+        if not api_key:
+            print("Error: RECRAFT_API_KEY not set; pass --dry-run or --mock-provider "
+                  "to skip the live call.", file=sys.stderr)
+            return 1
+        provider = _RecraftProvider(api_key=api_key, references_dir=references_dir)
+
+    report = scan(
+        library_root,
+        threshold_bits=args.threshold_bits,
+        regenerate=provider.regenerate,
+        references_dir=references_dir,
+    )
+    md = render_markdown(report)
+
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(md, encoding="utf-8")
+        print(f"Report: {args.report}")
+    else:
+        print(md)
+
+    drifted, _, errored = report.by_severity()
+    if drifted:
+        return 1  # gate-suitable
+    if errored and not (args.dry_run or args.mock_provider):
+        return 1  # only treat errors as failure when running for real
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/style_drift_scan.py
+++ b/scripts/style_drift_scan.py
@@ -306,7 +306,7 @@ def main() -> int:
                              "(default: <library-root>/_style-references)")
     parser.add_argument("--threshold-bits", type=int, default=12,
                         help="Hamming distance (out of 64) above which to flag "
-                             "drift (default: 12 bits ≈ 18.75%)")
+                             "drift (default: 12 / 64 ≈ 19 %% bit-flip)")
     parser.add_argument("--report", type=Path, default=None,
                         help="markdown report output path (default: stdout)")
     parser.add_argument("--dry-run", action="store_true",

--- a/scripts/text_collision_check.py
+++ b/scripts/text_collision_check.py
@@ -79,11 +79,11 @@ def _heuristic_bbox(elem: etree._Element) -> Bbox | None:
         fs = float(fs_raw.replace("px", "").replace("pt", ""))
     except ValueError:
         fs = 16.0
-    text = (elem.text or "").strip()
-    if not text:
-        # may have <tspan> children — concatenate their text
-        text = "".join((c.text or "") for c in elem)
-    text = text.strip()
+    # Concatenate the entire text subtree (text + every <tspan>'s text +
+    # tail text). The previous one-level-deep walk missed common
+    # `<text><tspan>A</tspan> tail</text>` patterns that produce a real
+    # bbox on screen but read as empty here, hiding overlaps.
+    text = "".join(elem.itertext()).strip()
 
     if not text:
         return None
@@ -93,7 +93,10 @@ def _heuristic_bbox(elem: etree._Element) -> Bbox | None:
     width = max(len(text) * fs * 0.55, fs)
     height = fs * 1.2
 
-    anchor = (elem.get("text-anchor") or "start").lower()
+    # `text-anchor` inherits down the SVG tree, so a single `<g
+    # text-anchor="middle">` wrapper around several `<text>` children
+    # was previously unseen and made the heuristic mis-place each cell.
+    anchor = (_walk_inherited(elem, "text-anchor") or "start").lower()
     if anchor == "middle":
         x -= width / 2
     elif anchor == "end":
@@ -262,7 +265,14 @@ def main() -> int:
               file=sys.stderr)
 
     if args.render_overlay:
-        render_overlay(args.svg, args.render_overlay, overlaps, pairs)
+        try:
+            render_overlay(args.svg, args.render_overlay, overlaps, pairs)
+        except OSError as exc:
+            # Same CI-friendly contract as the parse-failure branch
+            # above: never let a write failure dump a traceback.
+            print(f"Error: failed to write overlay {args.render_overlay}: {exc}",
+                  file=sys.stderr)
+            return 2
         print(f"\nOverlay written to: {args.render_overlay}", file=sys.stderr)
 
     return 1  # non-zero so CI can gate on it

--- a/scripts/text_collision_check.py
+++ b/scripts/text_collision_check.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+text_collision_check.py — flag overlapping `<text>` bboxes in an SVG.
+
+The LLM-writes-SVG path (SKILL.md §1.0a) has one well-known failure mode:
+two `<text>` nodes end up at coordinates that visually overlap. This is
+the script SKILL.md §1.0a's `# python scripts/text_collision_check.py` hint
+points at.
+
+Usage:
+  python text_collision_check.py figure.svg
+  python text_collision_check.py figure.svg --threshold 4
+  python text_collision_check.py figure.svg --render-overlay collisions.svg
+
+Exits 0 if no overlaps; non-zero with structured stderr output otherwise.
+
+Bbox derivation strategy:
+  - Prefer Inkscape `--query-{x,y,width,height}` per element when an
+    `inkscape` binary is on PATH. Inkscape resolves text shaping +
+    inheritance + transforms exactly.
+  - Fall back to a heuristic that parses `x` / `y` / `font-size` /
+    `text-anchor` directly. Width estimated as
+        text_length * font_size * 0.55  (roughly Arial average advance)
+    Height ≈ font_size * 1.2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from lxml import etree
+
+
+SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+SVG_TAG = "{http://www.w3.org/2000/svg}"
+
+
+@dataclass(frozen=True)
+class Bbox:
+    """A rectangle, all values in viewBox user units."""
+    x: float
+    y: float
+    w: float
+    h: float
+
+    @property
+    def x2(self) -> float:
+        return self.x + self.w
+
+    @property
+    def y2(self) -> float:
+        return self.y + self.h
+
+    def overlap_area(self, other: "Bbox") -> float:
+        ox1 = max(self.x, other.x)
+        oy1 = max(self.y, other.y)
+        ox2 = min(self.x2, other.x2)
+        oy2 = min(self.y2, other.y2)
+        if ox2 <= ox1 or oy2 <= oy1:
+            return 0.0
+        return (ox2 - ox1) * (oy2 - oy1)
+
+
+def _heuristic_bbox(elem: etree._Element) -> Bbox | None:
+    """Estimate a `<text>` bbox from x / y / font-size / text-anchor / text length."""
+    try:
+        x = float(elem.get("x") or 0.0)
+        y = float(elem.get("y") or 0.0)
+    except ValueError:
+        return None
+
+    fs_raw = elem.get("font-size") or _walk_inherited(elem, "font-size") or "16"
+    try:
+        fs = float(fs_raw.replace("px", "").replace("pt", ""))
+    except ValueError:
+        fs = 16.0
+    text = (elem.text or "").strip()
+    if not text:
+        # may have <tspan> children — concatenate their text
+        text = "".join((c.text or "") for c in elem)
+    text = text.strip()
+
+    if not text:
+        return None
+
+    # Crude advance-width heuristic. Real proportional fonts vary, but this
+    # is good enough to spot gross overlaps.
+    width = max(len(text) * fs * 0.55, fs)
+    height = fs * 1.2
+
+    anchor = (elem.get("text-anchor") or "start").lower()
+    if anchor == "middle":
+        x -= width / 2
+    elif anchor == "end":
+        x -= width
+
+    # SVG `<text>` y is the baseline; bbox top is roughly y - 0.8 * fs.
+    top = y - 0.8 * fs
+    return Bbox(x=x, y=top, w=width, h=height)
+
+
+def _walk_inherited(elem: etree._Element, attr: str) -> str | None:
+    cur: etree._Element | None = elem
+    while cur is not None:
+        v = cur.get(attr)
+        if v:
+            return v
+        cur = cur.getparent()
+    return None
+
+
+def _inkscape_bbox(svg_path: Path, element_id: str) -> Bbox | None:
+    """Ask Inkscape to compute the bbox; returns None on any error."""
+    try:
+        out = subprocess.run(
+            [
+                "inkscape", str(svg_path),
+                f"--query-id={element_id}",
+                "--query-x", "--query-y",
+                "--query-width", "--query-height",
+            ],
+            capture_output=True, text=True, check=True, timeout=10,
+        ).stdout
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    parts = out.strip().splitlines()
+    if len(parts) != 4:
+        return None
+    try:
+        x, y, w, h = map(float, parts)
+    except ValueError:
+        return None
+    return Bbox(x=x, y=y, w=w, h=h)
+
+
+def collect_text_bboxes(svg_path: Path, *, use_inkscape: bool) -> list[tuple[etree._Element, Bbox]]:
+    """Return [(text_element, bbox), …] for every <text> in the document.
+
+    `use_inkscape=True` uses Inkscape's exact-shaping bbox per element; falls
+    back to the heuristic when Inkscape is unavailable or errors on a node.
+    """
+    tree = etree.parse(str(svg_path))
+    root = tree.getroot()
+    text_elements = root.findall(".//svg:text", SVG_NS)
+    inkscape_available = use_inkscape and shutil.which("inkscape") is not None
+
+    pairs: list[tuple[etree._Element, Bbox]] = []
+    for elem in text_elements:
+        bbox: Bbox | None = None
+        eid = elem.get("id")
+        if inkscape_available and eid:
+            bbox = _inkscape_bbox(svg_path, eid)
+        if bbox is None:
+            bbox = _heuristic_bbox(elem)
+        if bbox is not None:
+            pairs.append((elem, bbox))
+    return pairs
+
+
+def find_overlaps(
+    pairs: list[tuple[etree._Element, Bbox]],
+    *,
+    threshold: float,
+) -> list[tuple[etree._Element, etree._Element, float]]:
+    """Return [(text_a, text_b, overlap_area)] for every pair > threshold."""
+    overlaps: list[tuple[etree._Element, etree._Element, float]] = []
+    for i in range(len(pairs)):
+        a_elem, a_box = pairs[i]
+        for j in range(i + 1, len(pairs)):
+            b_elem, b_box = pairs[j]
+            area = a_box.overlap_area(b_box)
+            if area > threshold:
+                overlaps.append((a_elem, b_elem, area))
+    return overlaps
+
+
+def _label(elem: etree._Element) -> str:
+    eid = elem.get("id")
+    if eid:
+        return f"#{eid}"
+    text = (elem.text or "").strip()[:30]
+    return f"<text>{text!r}"
+
+
+def render_overlay(
+    svg_path: Path,
+    out_path: Path,
+    overlaps: list[tuple[etree._Element, etree._Element, float]],
+    pairs: list[tuple[etree._Element, Bbox]],
+) -> None:
+    """Copy the SVG and overlay red rects on each colliding text bbox."""
+    tree = etree.parse(str(svg_path))
+    root = tree.getroot()
+    bbox_by_elem = {id(e): b for e, b in pairs}
+    flagged: set[int] = set()
+    for a, b, _ in overlaps:
+        flagged.add(id(a))
+        flagged.add(id(b))
+    for elem_id_int in flagged:
+        bbox = bbox_by_elem.get(elem_id_int)
+        if bbox is None:
+            continue
+        rect = etree.SubElement(
+            root, f"{SVG_TAG}rect",
+            attrib={
+                "x": str(bbox.x), "y": str(bbox.y),
+                "width": str(bbox.w), "height": str(bbox.h),
+                "fill": "none", "stroke": "#ff0033",
+                "stroke-width": "1.5", "stroke-dasharray": "4,2",
+                "class": "text-collision-overlay",
+            },
+        )
+        # Add a subtle title for tooltip in browsers.
+        etree.SubElement(rect, f"{SVG_TAG}title").text = "text bbox collision"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(str(out_path), xml_declaration=True, encoding="utf-8", pretty_print=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect overlapping <text> bboxes in an SVG figure",
+    )
+    parser.add_argument("svg", type=Path, help="path to the SVG to check")
+    parser.add_argument("--threshold", type=float, default=0.0,
+                        help="minimum overlap area (in viewBox units²) to report (default: 0)")
+    parser.add_argument("--render-overlay", type=Path, default=None,
+                        help="optional output SVG with red dashed rectangles drawn on every "
+                             "colliding text bbox")
+    parser.add_argument("--no-inkscape", action="store_true",
+                        help="skip the Inkscape exact-bbox query and use the heuristic only "
+                             "(faster + works without Inkscape installed)")
+    args = parser.parse_args()
+
+    if not args.svg.exists():
+        print(f"Error: SVG not found: {args.svg}", file=sys.stderr)
+        return 2
+
+    pairs = collect_text_bboxes(args.svg, use_inkscape=not args.no_inkscape)
+    overlaps = find_overlaps(pairs, threshold=args.threshold)
+
+    if not overlaps:
+        print(f"OK: no <text> bbox overlaps in {args.svg.name} "
+              f"(checked {len(pairs)} text elements, threshold={args.threshold})")
+        return 0
+
+    print(f"FOUND {len(overlaps)} <text> bbox overlap(s) in {args.svg.name}:",
+          file=sys.stderr)
+    for a, b, area in sorted(overlaps, key=lambda t: -t[2]):
+        print(f"  {_label(a)} ⨯ {_label(b)}  overlap={area:.1f} units²",
+              file=sys.stderr)
+
+    if args.render_overlay:
+        render_overlay(args.svg, args.render_overlay, overlaps, pairs)
+        print(f"\nOverlay written to: {args.render_overlay}", file=sys.stderr)
+
+    return 1  # non-zero so CI can gate on it
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/text_collision_check.py
+++ b/scripts/text_collision_check.py
@@ -240,7 +240,14 @@ def main() -> int:
         print(f"Error: SVG not found: {args.svg}", file=sys.stderr)
         return 2
 
-    pairs = collect_text_bboxes(args.svg, use_inkscape=not args.no_inkscape)
+    try:
+        pairs = collect_text_bboxes(args.svg, use_inkscape=not args.no_inkscape)
+    except (etree.XMLSyntaxError, etree.ParseError, OSError) as exc:
+        # Convert lxml exceptions into a stable CLI error code so callers
+        # (CI gates, the assemble_figure post-step) get a predictable
+        # signal instead of a Python traceback.
+        print(f"Error: failed to parse SVG: {exc}", file=sys.stderr)
+        return 2
     overlaps = find_overlaps(pairs, threshold=args.threshold)
 
     if not overlaps:


### PR DESCRIPTION
## Summary / 概要

Closes 9 of the 10 issues filed against milestone [v0.1.2](https://github.com/WuyangFF95/CC_icons/milestone/1) in a single PR (issue [#3 BioRender](https://github.com/WuyangFF95/CC_icons/issues/3) stays open — `depends-on-external`).

一次 PR 关掉 milestone v0.1.2 下的 10 个 issue 中的 9 个（[#3 BioRender](https://github.com/WuyangFF95/CC_icons/issues/3) 因 `depends-on-external` 维持开放）。

## Closes

| Issue | Commit | What |
|---|---|---|
| Closes #10 | [`fd4cc79`](../commit/fd4cc79) | refactor: narrow `except Exception:` → 5 specific tuples; new `_RENDER_EXCEPTIONS` for cmd_preview / cmd_export render loops |
| Closes #11 | [`b354058`](../commit/b354058) | feat: PhyloPic raster fallback (`--phylopic-allow-raster`); content-type sniff overrides ext; `format` field on each record; `library_tools.stats` adds vector/raster counts |
| Closes #8 | [`87ebacd`](../commit/87ebacd) | feat: `_journal-configs/` with 6 starter YAMLs + `assemble_figure.py --journal <name>` validator (forbidden fonts / font-size floors / stroke-width floors fail the build) |
| Closes #4 | [`7402d77`](../commit/7402d77) | feat: `scripts/text_collision_check.py` — Inkscape exact-bbox + heuristic fallback; `--render-overlay` writes red dashed boxes around colliding text; SKILL.md §1.0a hookup |
| Closes #6 | [`2870c6f`](../commit/2870c6f) | feat: `cmd_preview --html` mode — self-contained interactive HTML grid with click-to-download; data-URI thumbnails |
| Closes #2 | [`0edc5c2`](../commit/0edc5c2) | feat: `scripts/lowfi_trace.py` + `_palettes/` — gradient flatten → palette snap → stroke clamp; 3 starter palettes including the bundled template's |
| Closes #5 | [`faa06ad`](../commit/faa06ad) | feat: `scripts/library_build_static.py` — global library catalog HTML with sticky filters (source / category / license / CC-BY-only) + JS full-text search |
| Closes #7 | [`577a183`](../commit/577a183) | feat: `scripts/style_drift_scan.py` — 8x8 average-hash Hamming drift detector; `--dry-run` mock provider; markdown report with drifted / stable / errored buckets |
| Closes #9 | [`1b5f236`](../commit/1b5f236) | feat: `scripts/auto_fill_manifest.py` — parse template → propose semantics (mock today, live deferred) → search library → emit manifest YAML with TODO notes for unresolved slots |

Plus one chore: [`a55956a`](../commit/a55956a) `chore: add .gstack/ to .gitignore`.

Stays open: [#3 BioRender MCP connector](https://github.com/WuyangFF95/CC_icons/issues/3) — blocked on a stable BioRender MCP exposing tool-use; reopen this PR or file a follow-up when that lands.

## Files changed / 改动文件

```
.gitignore                         | +1
_journal-configs/                  | +7 files (6 yamls + README)
_palettes/                         | +3 files (2 yamls + README)
scripts/auto_fill_manifest.py      | +342 (new)
scripts/library_build_static.py    | +312 (new)
scripts/lowfi_trace.py             | +351 (new)
scripts/style_drift_scan.py        | +371 (new)
scripts/text_collision_check.py    | +259 (new)
scripts/assemble_figure.py         | +203 / -2  (new --journal validator)
scripts/download_cc0_seed.py       | +93 / -8   (PhyloPic raster fallback)
scripts/library_tools.py           | +169 / -10 (--html mode + narrow excepts + stats fmt)
```

## Validation / 验证

```
[OK] python -c "import ast; ast.parse(...)"  for all 8 .py files in scripts/
[OK] --help on every new + existing CLI (text_collision_check, lowfi_trace,
     library_build_static, style_drift_scan, auto_fill_manifest +
     library_tools, download_cc0_seed, assemble_figure)
[OK] template SVG + manifest YAML parse
[OK] all 6 _journal-configs/*.yaml + 2 _palettes/*.yaml parse

Smoke tests run inline during each commit (see commit messages):
[OK] cmd_register slugify rejects path-traversal
[OK] _namespace_subtree_ids preserves wrapper id, prefixes children
[OK] viewBox parsing handles 4 shapes (whitespace / comma / mixed / padded)
[OK] _pick_phylopic_source picks largest raster + falls back correctly
[OK] PhyloPic UUID 12-char prefix vs 8-char (~600× collision improvement)
[OK] journal validator: nature passes, cell warns on >8pt titles, Comic
     Sans triggers error
[OK] text_collision_check: synthetic overlap detected, exit 1; clean
     template, exit 0
[OK] lowfi_trace: snaps #FF0033 to #A32D2D against the dark-proteome palette
[OK] auto_fill_manifest: 26 placeholders + 33 labels parsed from
     dark_proteome template; mock mode emits TODO scaffolding
```

## Manual test plan / 手动测试

- [ ] Bootstrap a small library: `python scripts/download_cc0_seed.py --source bioicons`
- [ ] Browse it: `python scripts/library_build_static.py && open ~/sci-illustration-library/_browse/index.html`
- [ ] Search-and-preview: `python scripts/library_tools.py preview --query "T cell" --html /tmp/preview.html && open /tmp/preview.html`
- [ ] Normalize style: `python scripts/lowfi_trace.py --palette _palettes/dark-proteome-mixed.yaml --stroke-width 1.5 --dry-run`
- [ ] Build a figure with journal validation: `python scripts/assemble_figure.py --template templates/dark_proteome_4panel_template.svg --manifest templates/dark_proteome_manifest.yaml --output /tmp/fig.svg --journal nature-reviews-drug-discovery`
- [ ] Check text overlaps: `python scripts/text_collision_check.py /tmp/fig.svg`
- [ ] Drift scan dry-run: `python scripts/style_drift_scan.py --dry-run`
- [ ] Auto-fill scaffold: `python scripts/auto_fill_manifest.py --template templates/dark_proteome_4panel_template.svg --description "..." --output /tmp/manifest.yaml --dry-run`

## Notes for review / 评审注

The 9 commits are deliberately one-issue-per-commit so reviewers can pin discussion to a specific feature. Each commit message includes:
  - which issue it closes (the trailing `Closes #N` is what GitHub picks up to auto-close on merge)
  - the implementation sketch
  - the smoke test that was run

10 个 commit 故意一次只关一个 issue，review 时讨论可以挂在具体 feature 上。每个 commit message 都含：
  - 所关 issue 编号（GitHub 见 trailing `Closes #N` 会在 merge 时自动关闭）
  - 实现要点
  - 已跑的 smoke 测

Two items that intentionally ship as scaffolding rather than fully wired:
  - `style_drift_scan.py` — live Recraft regen call deferred (raises `NotImplementedError`); `--dry-run` / `--mock-provider` work today as a CI smoke check.
  - `auto_fill_manifest.py --llm-mode live` — same pattern; `mock` mode (default) generates a TODO scaffold today.

These two ship the plumbing now so the live wiring can be a small follow-up commit in v0.1.3 once the canonical LLM provider for this skill is decided (per SKILL.md §1.0a, MiniMax is the strong candidate).

两项有意以骨架交付而非完整接入：
  - `style_drift_scan.py` —— Recraft 实际生成调用待落地（抛
    `NotImplementedError`）；`--dry-run` / `--mock-provider` 当前可作 CI smoke 测。
  - `auto_fill_manifest.py --llm-mode live` —— 同模式；`mock` 模式（默认）当前产 TODO 骨架。

这两项现在交付管道，后续在 v0.1.3 选定 canonical LLM provider 后（按 SKILL.md §1.0a，MiniMax 是强候选）一个小 follow-up commit 即可接入。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wuyangff95/cc_icons/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->